### PR TITLE
add notifications feature for received payments

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -3,6 +3,7 @@ import type { Database as DatabaseGenerated } from 'supabase/database.types';
 import type { MergeDeep } from 'type-fest';
 import type { Currency, CurrencyUnit } from '~/lib/money';
 import type { AccountType } from '../accounts/account';
+import type { NotificationType } from '../notifications/notification';
 import type { CashuSendSwap } from '../send/cashu-send-swap';
 import type { Transaction } from '../transactions/transaction';
 import { supabaseSessionStore } from './supabase-session-store';
@@ -163,6 +164,11 @@ export type Database = MergeDeep<
             state: Transaction['state'];
           };
         };
+        notifications: {
+          Row: {
+            type: NotificationType;
+          };
+        };
       };
       Functions: {
         upsert_user_with_accounts: {
@@ -236,3 +242,5 @@ export type AgicashDbTransaction =
 export type AgicashDbContact = Database['wallet']['Tables']['contacts']['Row'];
 export type AgicashDbCashuSendSwap =
   Database['wallet']['Tables']['cashu_send_swaps']['Row'];
+export type AgicashDbNotification =
+  Database['wallet']['Tables']['notifications']['Row'];

--- a/app/features/notifications/notification-hooks.ts
+++ b/app/features/notifications/notification-hooks.ts
@@ -1,0 +1,185 @@
+import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import {
+  type UseSuspenseQueryResult,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { useSupabaseRealtimeSubscription } from '~/lib/supabase/supabase-realtime';
+import { useLatest } from '~/lib/use-latest';
+import { type AgicashDbNotification, agicashDb } from '../agicash-db/database';
+import { useUserRef } from '../user/user-hooks';
+import type { Notification, NotificationType } from './notification';
+import { useNotificationRepository } from './notification-repository';
+
+const notificationsQueryKey = 'notifications';
+
+/**
+ * Returns a suspense query that returns all notifications of the given type.
+ */
+export function useNotifications<
+  T extends NotificationType = NotificationType,
+>(select: { type: T }): UseSuspenseQueryResult<Notification<T>[]> {
+  const notificationRepository = useNotificationRepository();
+  const userRef = useUserRef();
+
+  return useSuspenseQuery({
+    queryKey: [notificationsQueryKey, select.type],
+    queryFn: () =>
+      notificationRepository.list({
+        userId: userRef.current.id,
+        type: select.type,
+      }),
+    staleTime: 0,
+    refetchOnMount: 'always',
+    select: (data) =>
+      data.filter((n): n is Notification<T> => n.type === select.type),
+  });
+}
+
+export function useNotificationByTransactionId(transactionId: string) {
+  const notificationRepository = useNotificationRepository();
+
+  return useSuspenseQuery({
+    queryKey: [notificationsQueryKey, 'byTransactionId', transactionId],
+    queryFn: () => notificationRepository.getByTransactionId(transactionId),
+  });
+}
+
+export function useHasNotifications(select: {
+  type: NotificationType;
+}): UseSuspenseQueryResult<boolean> {
+  const notificationRepository = useNotificationRepository();
+  const userRef = useUserRef();
+
+  return useSuspenseQuery({
+    queryKey: [notificationsQueryKey, 'has', select.type],
+    queryFn: () =>
+      notificationRepository.hasNotifications({
+        userId: userRef.current.id,
+        type: select?.type,
+      }),
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  });
+}
+
+/**
+ * Returns a mutation that deletes a set of notifications.
+ */
+export function useDeleteNotification() {
+  const notificationRepository = useNotificationRepository();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ notificationId }: { notificationId: string }) =>
+      notificationRepository.delete(notificationId),
+    retry: 3,
+    onSuccess: () => {
+      // We do not know if there are any other notifications of the same type, so we invalidate all of them.
+      queryClient.invalidateQueries({
+        queryKey: [notificationsQueryKey, 'has'],
+      });
+    },
+  });
+}
+
+/**
+ * Returns a mutation that deletes all notifications of a specific type.
+ * Checks the cache first and only makes the API call if notifications exist.
+ */
+export function useDeleteAllNotificationsByType({
+  type,
+}: { type: NotificationType }) {
+  const { data: hasNotifications } = useHasNotifications({ type });
+  const notificationRepository = useNotificationRepository();
+  const userRef = useUserRef();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => {
+      if (!hasNotifications) {
+        // No notifications to delete, return early
+        return Promise.resolve();
+      }
+
+      return notificationRepository.deleteAllByType({
+        userId: userRef.current.id,
+        type,
+      });
+    },
+    onSuccess: () => {
+      // We know that all notifications of this type have been deleted, so we can set the cache to false.
+      queryClient.setQueryData<boolean>(
+        [notificationsQueryKey, 'has', type],
+        false,
+      );
+    },
+    retry: 3,
+  });
+}
+
+function useOnNotificationCreated({
+  onCreated,
+}: {
+  onCreated: (notification: Notification) => void;
+}) {
+  const onCreatedRef = useLatest(onCreated);
+  const notificationRepository = useNotificationRepository();
+  const queryClient = useQueryClient();
+
+  return useSupabaseRealtimeSubscription({
+    channelFactory: () =>
+      agicashDb.channel('notifications').on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'wallet',
+          table: 'notifications',
+        },
+        async (
+          payload: RealtimePostgresChangesPayload<AgicashDbNotification>,
+        ) => {
+          if (payload.eventType === 'INSERT') {
+            const createdNotification = notificationRepository.toNotification(
+              payload.new,
+            );
+            onCreatedRef.current(createdNotification);
+          }
+        },
+      ),
+    onReconnected: () => {
+      // Invalidate the hasNotifications queries so that they are re-fetched and the cache is updated.
+      // This is needed to get any data that might have been updated while the re-connection was in progress.
+      queryClient.invalidateQueries({
+        queryKey: [notificationsQueryKey, 'has'],
+      });
+    },
+  });
+}
+
+/**
+ * Subscribes to changes in the notifications table and keeps the hasNotifications queries up to date.
+ */
+export function useTrackHasNotifications() {
+  const queryClient = useQueryClient();
+
+  return useOnNotificationCreated({
+    onCreated: (notification) => {
+      queryClient.setQueryData<boolean>(
+        [notificationsQueryKey, 'has', notification.type],
+        true,
+      );
+      if (notification.type === 'PAYMENT_RECEIVED') {
+        queryClient.setQueryData<Notification | null>(
+          [
+            notificationsQueryKey,
+            'byTransactionId',
+            notification.transactionId,
+          ],
+          notification,
+        );
+      }
+    },
+  });
+}

--- a/app/features/notifications/notification-repository.ts
+++ b/app/features/notifications/notification-repository.ts
@@ -1,0 +1,164 @@
+import {
+  type AgicashDb,
+  type AgicashDbNotification,
+  agicashDb,
+} from '../agicash-db/database';
+import type { Notification, NotificationType } from './notification';
+
+type Options = {
+  abortSignal?: AbortSignal;
+};
+
+class NotificationRepository {
+  constructor(private readonly db: AgicashDb) {}
+
+  /**
+   * Lists all notifications of the given type in descending order of creation date.
+   * If no type is provided, all notifications are returned.
+   */
+  async list(
+    { userId, type }: { userId: string; type?: NotificationType },
+    options?: Options,
+  ): Promise<Notification[]> {
+    const query = this.db
+      .from('notifications')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    if (type) {
+      query.eq('type', type);
+    }
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error('Failed to list notifications.', { cause: error });
+    }
+
+    return data.map(this.toNotification);
+  }
+
+  async getByTransactionId(
+    transactionId: string,
+    options?: Options,
+  ): Promise<Notification | null> {
+    const query = this.db
+      .from('notifications')
+      .select('*')
+      .limit(1)
+      .eq('transaction_id', transactionId);
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      throw new Error('Failed to get notification by transaction id.', {
+        cause: error,
+      });
+    }
+
+    if (data.length === 0) {
+      return null;
+    }
+
+    return this.toNotification(data[0]);
+  }
+
+  /**
+   * Checks if the user has any notifications of the given type.
+   * If no type is provided, any notifications are checked.
+   */
+  async hasNotifications(
+    { userId, type }: { userId: string; type?: NotificationType },
+    options?: Options,
+  ): Promise<boolean> {
+    const query = this.db
+      .from('notifications')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId);
+    if (type) {
+      query.eq('type', type);
+    }
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { count, error } = await query;
+    if (error) {
+      throw new Error('Failed to check for notifications.', { cause: error });
+    }
+
+    return (count ?? 0) > 0;
+  }
+
+  /**
+   * Deletes a notification by id.
+   */
+  async delete(notificationId: string, options?: Options): Promise<void> {
+    const query = this.db
+      .from('notifications')
+      .delete()
+      .eq('id', notificationId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { error } = await query;
+    if (error) {
+      throw new Error('Failed to delete notification.', {
+        cause: error,
+      });
+    }
+  }
+
+  /**
+   * Deletes all notifications of a specific type for a user.
+   */
+  async deleteAllByType(
+    { userId, type }: { userId: string; type: NotificationType },
+    options?: Options,
+  ): Promise<void> {
+    const query = this.db.from('notifications').delete().match({
+      user_id: userId,
+      type: type,
+    });
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { error } = await query;
+    if (error) {
+      throw new Error('Failed to delete notifications by type.', {
+        cause: error,
+      });
+    }
+  }
+
+  toNotification(data: AgicashDbNotification): Notification {
+    const baseNotification = {
+      id: data.id,
+      createdAt: data.created_at,
+    };
+
+    if (data.type === 'PAYMENT_RECEIVED' && data.transaction_id) {
+      return {
+        ...baseNotification,
+        type: 'PAYMENT_RECEIVED',
+        transactionId: data.transaction_id,
+      };
+    }
+
+    throw new Error('Invalid notification data', { cause: data });
+  }
+}
+
+export function useNotificationRepository() {
+  return new NotificationRepository(agicashDb);
+}

--- a/app/features/notifications/notification.ts
+++ b/app/features/notifications/notification.ts
@@ -1,0 +1,17 @@
+export type NotificationType = 'PAYMENT_RECEIVED';
+
+export type Notification<T extends NotificationType = NotificationType> = {
+  /** The ID of the notification. */
+  id: string;
+  /**
+   * The type of notification.
+   * - PAYMENT_RECEIVED: A receive transaction was completed and transaction history was updated.
+   */
+  type: T;
+  /** The date and time the notification was created in ISO 8601 format. */
+  createdAt: string;
+} & {
+  type: 'PAYMENT_RECEIVED';
+  /** The ID of the received transaction that triggered the notification. */
+  transactionId: string;
+};

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -6,6 +6,7 @@ import {
   UndoIcon,
   XIcon,
 } from 'lucide-react';
+import { useEffect } from 'react';
 
 import { PageContent, PageFooter } from '~/components/page';
 import { Button } from '~/components/ui/button';
@@ -27,6 +28,10 @@ import type {
 import { useToast } from '~/hooks/use-toast';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { useAccount } from '../accounts/account-hooks';
+import {
+  useDeleteNotification,
+  useNotificationByTransactionId,
+} from '../notifications/notification-hooks';
 import { getDefaultUnit } from '../shared/currencies';
 import { getErrorMessage } from '../shared/error';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
@@ -114,6 +119,15 @@ export function TransactionDetails({
       });
     },
   });
+
+  const { data: notification } = useNotificationByTransactionId(transaction.id);
+  const { mutate: deleteNotification } = useDeleteNotification();
+
+  useEffect(() => {
+    if (notification && ['COMPLETED', 'REVERSED'].includes(transaction.state)) {
+      deleteNotification({ notificationId: notification.id });
+    }
+  }, [notification, transaction.state, deleteNotification]);
 
   const isWaitingForStateUpdate =
     didReclaimMutationSucceed &&

--- a/app/features/wallet/wallet.tsx
+++ b/app/features/wallet/wallet.tsx
@@ -5,6 +5,7 @@ import { useToast } from '~/hooks/use-toast';
 import { useTrackAccounts } from '../accounts/account-hooks';
 import { supabaseSessionStore } from '../agicash-db/supabase-session-store';
 import { LoadingScreen } from '../loading/LoadingScreen';
+import { useTrackHasNotifications } from '../notifications/notification-hooks';
 import { useTrackPendingCashuReceiveQuotes } from '../receive/cashu-receive-quote-hooks';
 import { useTrackPendingCashuTokenSwaps } from '../receive/cashu-token-swap-hooks';
 import { useTrackUnresolvedCashuSendQuotes } from '../send/cashu-send-quote-hooks';
@@ -88,6 +89,7 @@ const Wallet = ({ children }: PropsWithChildren) => {
   const isLead = useTakeTaskProcessingLead();
 
   const accountsSubscription = useTrackAccounts();
+  const hasNotificationsSubscription = useTrackHasNotifications();
   const pendingCashuReceiveQuotesSubscription =
     useTrackPendingCashuReceiveQuotes();
   const pendingCashuTokenSwapsSubscription = useTrackPendingCashuTokenSwaps();
@@ -98,6 +100,7 @@ const Wallet = ({ children }: PropsWithChildren) => {
 
   if (
     accountsSubscription === 'subscribing' ||
+    hasNotificationsSubscription === 'subscribing' ||
     pendingCashuReceiveQuotesSubscription === 'subscribing' ||
     pendingCashuTokenSwapsSubscription === 'subscribing' ||
     unresolvedCashuSendQuotesSubscription === 'subscribing' ||

--- a/app/routes/_protected._index.tsx
+++ b/app/routes/_protected._index.tsx
@@ -16,6 +16,7 @@ import {
   useDefaultAccount,
 } from '~/features/accounts/account-hooks';
 import { DefaultCurrencySwitcher } from '~/features/accounts/default-currency-switcher';
+import { useHasNotifications } from '~/features/notifications/notification-hooks';
 import { InstallPwaPrompt } from '~/features/pwa/install-pwa-prompt';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
 import { useExchangeRates } from '~/hooks/use-exchange-rate';
@@ -63,6 +64,9 @@ export default function Index() {
   const balanceBTC = useBalance('BTC');
   const balanceUSD = useBalance('USD');
   const defaultCurrency = useDefaultAccount().currency;
+  const { data: hasTransactionNotifications } = useHasNotifications({
+    type: 'PAYMENT_RECEIVED',
+  });
 
   return (
     <Page>
@@ -72,8 +76,12 @@ export default function Index() {
             to="/transactions"
             transition="slideLeft"
             applyTo="newView"
+            className="relative"
           >
             <Clock className="text-muted-foreground" />
+            {hasTransactionNotifications && (
+              <div className="-right-0 -top-0 absolute h-[8px] w-[8px] rounded-full bg-green-500" />
+            )}
           </LinkWithViewTransition>
           <LinkWithViewTransition
             to="/settings"

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -465,6 +465,45 @@ export type Database = {
           },
         ]
       }
+      notifications: {
+        Row: {
+          created_at: string
+          id: string
+          transaction_id: string | null
+          type: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          transaction_id?: string | null
+          type: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          transaction_id?: string | null
+          type?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notifications_transaction_id_fkey"
+            columns: ["transaction_id"]
+            isOneToOne: false
+            referencedRelation: "transactions"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notifications_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       task_processing_locks: {
         Row: {
           expires_at: string
@@ -921,8 +960,8 @@ export type Database = {
       find_contact_candidates: {
         Args: { current_user_id: string; partial_username: string }
         Returns: {
-          username: string
           id: string
+          username: string
         }[]
       }
       list_transactions: {

--- a/supabase/migrations/20250805212400_add_notifications.sql
+++ b/supabase/migrations/20250805212400_add_notifications.sql
@@ -1,0 +1,100 @@
+create table "wallet"."notifications" (
+    "id" uuid not null default gen_random_uuid(),
+    "created_at" timestamp with time zone not null default now(),
+    "user_id" uuid not null,
+    "transaction_id" uuid,
+    "type" text not null
+);
+
+alter table "wallet"."notifications" enable row level security;
+
+CREATE UNIQUE INDEX notifications_pkey ON wallet.notifications USING btree (id);
+
+alter table "wallet"."notifications" add constraint "notifications_pkey" PRIMARY KEY using index "notifications_pkey";
+
+alter table "wallet"."notifications" add constraint "notifications_transaction_id_fkey" FOREIGN KEY (transaction_id) REFERENCES wallet.transactions(id) not valid;
+
+alter table "wallet"."notifications" validate constraint "notifications_transaction_id_fkey";
+
+alter table "wallet"."notifications" add constraint "notifications_user_id_fkey" FOREIGN KEY (user_id) REFERENCES wallet.users(id) not valid;
+
+alter table "wallet"."notifications" validate constraint "notifications_user_id_fkey";
+
+set check_function_bodies = off;
+
+grant delete on table "wallet"."notifications" to "anon";
+
+grant insert on table "wallet"."notifications" to "anon";
+
+grant references on table "wallet"."notifications" to "anon";
+
+grant select on table "wallet"."notifications" to "anon";
+
+grant trigger on table "wallet"."notifications" to "anon";
+
+grant truncate on table "wallet"."notifications" to "anon";
+
+grant update on table "wallet"."notifications" to "anon";
+
+grant delete on table "wallet"."notifications" to "authenticated";
+
+grant insert on table "wallet"."notifications" to "authenticated";
+
+grant references on table "wallet"."notifications" to "authenticated";
+
+grant select on table "wallet"."notifications" to "authenticated";
+
+grant trigger on table "wallet"."notifications" to "authenticated";
+
+grant truncate on table "wallet"."notifications" to "authenticated";
+
+grant update on table "wallet"."notifications" to "authenticated";
+
+grant delete on table "wallet"."notifications" to "service_role";
+
+grant insert on table "wallet"."notifications" to "service_role";
+
+grant references on table "wallet"."notifications" to "service_role";
+
+grant select on table "wallet"."notifications" to "service_role";
+
+grant trigger on table "wallet"."notifications" to "service_role";
+
+grant truncate on table "wallet"."notifications" to "service_role";
+
+grant update on table "wallet"."notifications" to "service_role";
+
+create policy "Enable CRUD for notifications based on user_id"
+on "wallet"."notifications"
+as permissive
+for all
+to public
+using ((( SELECT auth.uid() AS uid) = user_id))
+with check ((( SELECT auth.uid() AS uid) = user_id));
+
+alter publication supabase_realtime add table wallet.notifications;
+
+-- Create a trigger to insert a notification whenever a RECEIVE transaction is completed
+create or replace function wallet.fn_create_notification_on_receive_completed()
+returns trigger
+language plpgsql
+as $$
+begin
+  -- Insert a PAYMENT_RECEIVED notification for the user when a RECEIVE transaction is marked COMPLETED
+  insert into wallet.notifications (user_id, transaction_id, type)
+  values (new.user_id, new.id, 'PAYMENT_RECEIVED');
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_create_notification_on_receive_completed on wallet.transactions;
+create trigger trg_create_notification_on_receive_completed
+after update of state on wallet.transactions
+for each row
+when (
+  old.state is distinct from new.state
+  and new.state = 'COMPLETED'
+  and new.direction = 'RECEIVE'
+)
+execute function wallet.fn_create_notification_on_receive_completed();


### PR DESCRIPTION
- create new notification feature
- update create_cashu_receive_quote and create_cashu_token_swap db functions to create notifcations referencing the completed transaction

We listen to realtime updates to monitor whether the user has any unread PAYMENT_RECEIVED notifications. If they do, then show a dot on the tx history icon. 
When the transaction list is opened all unread notifications are fetched and immediately marked as read. The query that fetches the notifications won't be affected by realtime updates, so the transactions maintain the unread dot on them until the transaction list is closed.