### PR TITLE
add unique constraint on quote ids

### DIFF
--- a/supabase/migrations/20250815170919_unique-quote-ids.sql
+++ b/supabase/migrations/20250815170919_unique-quote-ids.sql
@@ -1,0 +1,9 @@
+CREATE UNIQUE INDEX cashu_receive_quotes_quote_id_key ON wallet.cashu_receive_quotes USING btree (quote_id);
+
+CREATE UNIQUE INDEX cashu_send_quotes_quote_id_key ON wallet.cashu_send_quotes USING btree (quote_id);
+
+alter table "wallet"."cashu_receive_quotes" add constraint "cashu_receive_quotes_quote_id_key" UNIQUE using index "cashu_receive_quotes_quote_id_key";
+
+alter table "wallet"."cashu_send_quotes" add constraint "cashu_send_quotes_quote_id_key" UNIQUE using index "cashu_send_quotes_quote_id_key";
+
+


### PR DESCRIPTION
closes #582 

It seems that somehow multiple send quotes are being created with the same melt quote ID. This should not happen because a melt quote can only be paid once, so we don't want to try to pay it twice. I can not figure out how two quotes are being created, but my guess is that the first call to `initiateSend` from `useInitiateCashuSendQuote` successfully triggers the quote creation, but then the mutation retries maybe because of a network error. Retrying the mutation creates another send with new proofs to send. 

I added unique constraints to mint and melt quote IDs because there should only be one record in our db per quote. This is only half of the solution as it does not fix whatever is causing the call to create a send quote happen twice, but at least now we won't end up with a send quote that can't be completed.

> [!IMPORTANT]
> There cannot be any duplicates in the db when we run this migration. To check this, first run this script to see the records that would be deleted, then run the following script to delete them with associated trasnactions:

```sql
-- PREVIEW: Show what would be deleted (run this first to review)
WITH duplicates_to_delete AS (
    SELECT 
        id,
        quote_id,
        state,
        created_at,
        user_id,
        transaction_id,
        ROW_NUMBER() OVER (PARTITION BY quote_id ORDER BY created_at ASC) as row_num
    FROM wallet.cashu_send_quotes
),
send_quotes_to_delete AS (
    SELECT * 
    FROM duplicates_to_delete 
    WHERE row_num > 1
)
SELECT 
    'SEND_QUOTE' as record_type,
    id as record_id,
    quote_id,
    state,
    created_at,
    user_id,
    transaction_id
FROM send_quotes_to_delete
UNION ALL
SELECT 
    'TRANSACTION' as record_type,
    t.id as record_id,
    std.quote_id,
    t.state,
    t.created_at,
    t.user_id,
    t.id as transaction_id
FROM send_quotes_to_delete std
JOIN wallet.transactions t ON t.id = std.transaction_id
ORDER BY quote_id, record_type, created_at;
```

And then delete them with:

```sql
-- Delete duplicate send quotes and their associated records
-- This keeps the OLDEST record for each quote_id and deletes newer duplicates

DO $$
DECLARE
    duplicate_count INTEGER;
    deleted_count INTEGER;
BEGIN
    -- First, let's see what we're dealing with
    SELECT COUNT(*) INTO duplicate_count
    FROM (
        SELECT quote_id 
        FROM wallet.cashu_send_quotes 
        GROUP BY quote_id 
        HAVING COUNT(*) > 1
    ) duplicates;
    
    RAISE NOTICE 'Found % quote_ids with duplicates', duplicate_count;
    
    IF duplicate_count > 0 THEN
        -- Delete associated transactions for duplicate send quotes first
        -- (keeping transactions for the oldest send quote per quote_id)
        WITH duplicates_to_delete AS (
            SELECT 
                id,
                transaction_id,
                quote_id,
                created_at,
                ROW_NUMBER() OVER (PARTITION BY quote_id ORDER BY created_at ASC) as row_num
            FROM wallet.cashu_send_quotes
        ),
        transaction_ids_to_delete AS (
            SELECT DISTINCT transaction_id
            FROM duplicates_to_delete 
            WHERE row_num > 1
        )
        DELETE FROM wallet.transactions 
        WHERE id IN (SELECT transaction_id FROM transaction_ids_to_delete);
        
        GET DIAGNOSTICS deleted_count = ROW_COUNT;
        RAISE NOTICE 'Deleted % associated transactions', deleted_count;
        
        -- Now delete the duplicate send quotes (keeping the oldest one per quote_id)
        WITH duplicates_to_delete AS (
            SELECT 
                id,
                quote_id,
                created_at,
                state,
                ROW_NUMBER() OVER (PARTITION BY quote_id ORDER BY created_at ASC) as row_num
            FROM wallet.cashu_send_quotes
        )
        DELETE FROM wallet.cashu_send_quotes 
        WHERE id IN (
            SELECT id 
            FROM duplicates_to_delete 
            WHERE row_num > 1
        );
        
        GET DIAGNOSTICS deleted_count = ROW_COUNT;
        RAISE NOTICE 'Deleted % duplicate send quotes', deleted_count;
        
        -- Verify cleanup was successful
        SELECT COUNT(*) INTO duplicate_count
        FROM (
            SELECT quote_id 
            FROM wallet.cashu_send_quotes 
            GROUP BY quote_id 
            HAVING COUNT(*) > 1
        ) remaining_duplicates;
        
        IF duplicate_count > 0 THEN
            RAISE EXCEPTION 'Cleanup failed: Still have % duplicate quote_ids', duplicate_count;
        ELSE
            RAISE NOTICE 'Successfully cleaned up all duplicates';
        END IF;
    ELSE
        RAISE NOTICE 'No duplicates found - nothing to clean up';
    END IF;
END $$;
```