### PR TITLE
persist fetched tx data in outlet context

### DIFF
--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -1,13 +1,17 @@
 import { AlertCircle, BanknoteIcon, UserIcon, ZapIcon } from 'lucide-react';
 import { type Ref, useCallback, useEffect, useRef } from 'react';
+import { useOutletContext } from 'react-router';
 import { Card } from '~/components/ui/card';
 import { ScrollArea } from '~/components/ui/scroll-area';
 import { useIsVisible } from '~/hooks/use-is-visible';
 import { LinkWithViewTransition } from '~/lib/transitions';
+import type { TransactionsLayoutContext } from '~/routes/_protected.transactions';
 import { getDefaultUnit } from '../shared/currencies';
 import type { Transaction } from './transaction';
-import { useAcknowledgeTransaction } from './transaction-hooks';
-import { useTransactions } from './transaction-hooks';
+import {
+  useAckTransactionInCache,
+  useAcknowledgeTransaction,
+} from './transaction-hooks';
 
 function LoadMore({
   onEndReached,
@@ -119,6 +123,7 @@ function TransactionRow({
   transaction: Transaction;
 }) {
   const { mutate: acknowledgeTransaction } = useAcknowledgeTransaction();
+  const ackTransactionInCache = useAckTransactionInCache();
 
   const { ref } = useIsVisible({
     threshold: 0.5, // Consider visible when 50% of the element is in view
@@ -139,6 +144,7 @@ function TransactionRow({
       applyTo="newView"
       className="flex w-full items-center justify-start gap-4"
       ref={ref as Ref<HTMLAnchorElement>}
+      onClick={() => ackTransactionInCache(transaction.id)}
     >
       {getTransactionTypeIcon(transaction)}
       <div className="flex w-full flex-grow flex-col gap-0">
@@ -235,7 +241,7 @@ export function TransactionList() {
     hasNextPage,
     isFetchingNextPage,
     status,
-  } = useTransactions();
+  } = useOutletContext<TransactionsLayoutContext>();
 
   const allTransactions =
     data?.pages.flatMap((page) => page.transactions) ?? [];

--- a/app/routes/_protected.transactions.tsx
+++ b/app/routes/_protected.transactions.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router';
+import { useTransactions } from '~/features/transactions/transaction-hooks';
+
+export type TransactionsLayoutContext = ReturnType<typeof useTransactions>;
+
+export default function TransactionsLayout() {
+  const transactionsQuery = useTransactions();
+
+  return <Outlet context={transactionsQuery} />;
+}


### PR DESCRIPTION
> one way to do it could be to use refetchOnMount function on useInfiniteQuery and make the function return false when we are going from txn details page back to txn list that way the page would not refetch and it would use data from the cache that still has ack status pending

@jbojcic1 I tried your suggestion, but the problem is that we have to track the previous route path to know where we are coming from. We could do this with navigation state, but that seems like too much. React router doesn't seem to provide this functionality out of the box

This PR creates a transaction layout and passes the transaction query and data in through context so that as long as the transaction layout is being rendered the query will not be refetched. Then when the user navigates from the list to a details view we update the cache with useAckTransactionInCache