### PR TITLE
change tx amount for incomplete lightning sends

### DIFF
--- a/app/features/transactions/transaction-repository.ts
+++ b/app/features/transactions/transaction-repository.ts
@@ -216,7 +216,9 @@ export class TransactionRepository {
       const incompleteDetails =
         details as IncompleteCashuLightningSendTransactionDetails;
       return createTransaction(
-        incompleteDetails.amountReserved,
+        incompleteDetails.amountToReceive
+          .add(incompleteDetails.lightningFeeReserve)
+          .add(incompleteDetails.cashuSendFee),
         incompleteDetails,
       );
     }


### PR DESCRIPTION
this changes the transaction's amount in the repository for not completed lightning sends. This means the transaction list will show the same number as details