### PR TITLE
improve claim as guest flow, no jumping around

### DIFF
--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -332,7 +332,7 @@ export function useReceiveCashuTokenAccounts(
     selectableAccounts,
     receiveAccount,
     isCrossMintSwapDisabled,
-    sourceAccount: selectableAccounts.find((a) => a.id === sourceAccount.id),
+    sourceAccount: selectableAccounts[0],
     setReceiveAccount,
     addAndSetReceiveAccount,
   };

--- a/app/routes/_protected.receive.cashu_.token.tsx
+++ b/app/routes/_protected.receive.cashu_.token.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'react-router';
 import { Page } from '~/components/page';
 import { LoadingScreen } from '~/features/loading/LoadingScreen';
 import { ReceiveCashuToken } from '~/features/receive';
+import { ClaimAsGuestReceiveCashuToken } from '~/features/receive/receive-cashu-token';
 import { extractCashuToken } from '~/lib/cashu';
 import type { Route } from './+types/_protected.receive.cashu_.token';
 import { ReceiveCashuTokenSkeleton } from './receive-cashu-token-skeleton';
@@ -36,13 +37,18 @@ export default function ProtectedReceiveCashuToken({
 
   return (
     <Page>
-      <Suspense fallback={<ReceiveCashuTokenSkeleton />}>
-        <ReceiveCashuToken
-          token={token}
-          autoClaimToken={autoClaim}
-          preferredReceiveAccountId={selectedAccountId}
-        />
-      </Suspense>
+      {autoClaim ? (
+        <ClaimAsGuestReceiveCashuToken token={token} />
+      ) : (
+        <>
+          <Suspense fallback={<ReceiveCashuTokenSkeleton />}>
+            <ReceiveCashuToken
+              token={token}
+              preferredReceiveAccountId={selectedAccountId}
+            />
+          </Suspense>
+        </>
+      )}
     </Page>
   );
 }


### PR DESCRIPTION
I create a new component that will be rendered within the protected layout so that the user is loaded, but this component looks exactly the same as the public receive component. So now if auto claiming, then we will return the component identical to the public receive so that the screen doesn't change at all.

Maybe needs some name changes and docs, but all works well