### PR TITLE
Patch sentry to use passed timestamp

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -251,8 +251,12 @@ export const agicashDb = createClient<Database>(supabaseUrl, supabaseAnonKey, {
     logger: (kind: string, msg: unknown, data?: unknown) => {
       const now = Date.now();
       console.log(
-        `Realtime (${now} - ${new Date(now).toISOString()}) -> ${kind}: ${typeof msg === 'string' ? msg : JSON.stringify(msg)}`,
-        data,
+        `Realtime -> ${kind}: ${typeof msg === 'string' ? msg : JSON.stringify(msg)}`,
+        {
+          timestamp: now,
+          time: new Date(now).toISOString(),
+          data,
+        },
       );
     },
     logLevel: 'info',

--- a/patches/@sentry%2Fcore@10.14.0.patch
+++ b/patches/@sentry%2Fcore@10.14.0.patch
@@ -1,3 +1,54 @@
+diff --git a/node_modules/@sentry/core/.bun-tag-13c4c89a99b46fd b/.bun-tag-13c4c89a99b46fd
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@sentry/core/.bun-tag-7f447b0ab8be8393 b/.bun-tag-7f447b0ab8be8393
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@sentry/core/.bun-tag-93df3377343ec96 b/.bun-tag-93df3377343ec96
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@sentry/core/.bun-tag-aa8768c77c3af962 b/.bun-tag-aa8768c77c3af962
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@sentry/core/.bun-tag-bc6b85bd23c04b41 b/.bun-tag-bc6b85bd23c04b41
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@sentry/core/.bun-tag-c5e75f8b53dcbf28 b/.bun-tag-c5e75f8b53dcbf28
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@sentry/core/.bun-tag-d02cf43cb32db12a b/.bun-tag-d02cf43cb32db12a
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/build/cjs/logs/console-integration.js b/build/cjs/logs/console-integration.js
+index 6d53aa83fb09cc78a9634dfc4d4313fec572e3ea..fa3dacade9927ce6e4ca2a29b7e4c3c1d15a1a5e 100644
+--- a/build/cjs/logs/console-integration.js
++++ b/build/cjs/logs/console-integration.js
+@@ -55,7 +55,12 @@ const _consoleLoggingIntegration = ((options = {}) => {
+           ...(shouldGenerateTemplate ? utils.createConsoleTemplateAttributes(firstArg, followingArgs) : {}),
+         };
+ 
++        const secondArg = args[1];
++        const timestamp = secondArg && typeof secondArg === 'object' ? secondArg.timestamp : undefined;
++        const timestampInSeconds = timestamp ? timestamp / 1000 : undefined;
++
+         internal._INTERNAL_captureLog({
++          timestamp: timestampInSeconds,
+           level: isLevelLog ? 'info' : level,
+           message: utils.formatConsoleArgs(args, normalizeDepth, normalizeMaxBreadth),
+           severityNumber: isLevelLog ? 10 : undefined,
+diff --git a/build/cjs/logs/internal.js b/build/cjs/logs/internal.js
+index b6b11f4c6840e226a2b2b2c48714426c48113f03..9a70ceaf0480589e6af06b1a39ce67910174cd8e 100644
+--- a/build/cjs/logs/internal.js
++++ b/build/cjs/logs/internal.js
+@@ -182,7 +182,7 @@ function _INTERNAL_captureLog(
+   const { level, message, attributes = {}, severityNumber } = log;
+ 
+   const serializedLog = {
+-    timestamp: time.timestampInSeconds(),
++    timestamp: beforeLog.timestamp ?? time.timestampInSeconds(),
+     level,
+     body: message,
+     trace_id: traceContext?.trace_id,
 diff --git a/build/cjs/utils/time.js b/build/cjs/utils/time.js
 index f1632bc0a634a108aba0237f8e53fe6452ab4265..e832293b25c6c34b0efa4a03c6a6eb095f46d29d 100644
 --- a/build/cjs/utils/time.js
@@ -26,6 +77,36 @@ index f1632bc0a634a108aba0237f8e53fe6452ab4265..e832293b25c6c34b0efa4a03c6a6eb09
  }
  
  /**
+diff --git a/build/esm/logs/console-integration.js b/build/esm/logs/console-integration.js
+index 2811cc868dc1e36cec3a077a0893a0237d22e752..b6e043eafdc7df668b791a5514b5138b800615c1 100644
+--- a/build/esm/logs/console-integration.js
++++ b/build/esm/logs/console-integration.js
+@@ -53,7 +53,12 @@ const _consoleLoggingIntegration = ((options = {}) => {
+           ...(shouldGenerateTemplate ? createConsoleTemplateAttributes(firstArg, followingArgs) : {}),
+         };
+ 
++        const secondArg = args[1];
++        const timestamp = secondArg && typeof secondArg === 'object' ? secondArg.timestamp : undefined;
++        const timestampInSeconds = timestamp ? timestamp / 1000 : undefined;
++
+         _INTERNAL_captureLog({
++          timestamp: timestampInSeconds,
+           level: isLevelLog ? 'info' : level,
+           message: formatConsoleArgs(args, normalizeDepth, normalizeMaxBreadth),
+           severityNumber: isLevelLog ? 10 : undefined,
+diff --git a/build/esm/logs/internal.js b/build/esm/logs/internal.js
+index aa44af0802b69496e43e2ac82f8ff1733a091406..ca24568b413e69a557cb487e9a8c565f8ec69d06 100644
+--- a/build/esm/logs/internal.js
++++ b/build/esm/logs/internal.js
+@@ -180,7 +180,7 @@ function _INTERNAL_captureLog(
+   const { level, message, attributes = {}, severityNumber } = log;
+ 
+   const serializedLog = {
+-    timestamp: timestampInSeconds(),
++    timestamp: beforeLog.timestamp ?? timestampInSeconds(),
+     level,
+     body: message,
+     trace_id: traceContext?.trace_id,
 diff --git a/build/esm/utils/time.js b/build/esm/utils/time.js
 index 571c0d6278356a2c0ec6941760b8c0d951d4b074..05ab054b20849ee526d32d0d431b558e771e76a0 100644
 --- a/build/esm/utils/time.js


### PR DESCRIPTION
This a new attempt to try to change Sentry to fix timestamp issue with logs. The change is to actually send timestamp from the log itself so there should not be any mismatches