### PR TITLE
add `internal_melts_only` to MintInfo and cache mint info

### DIFF
--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -152,7 +152,7 @@ export const cashuMintValidator = buildMintValidator({
 export const mintInfoQueryOptions = (mintUrl: string) =>
   queryOptions({
     queryKey: ['mint-info', mintUrl],
-    queryFn: async () => getCashuWallet(mintUrl).getMintInfo(),
+    queryFn: async () => getCashuWallet(mintUrl).getExtendedMintInfo(),
     staleTime: 1000 * 60 * 60, // 1 hour
   });
 

--- a/app/lib/cashu/index.ts
+++ b/app/lib/cashu/index.ts
@@ -3,5 +3,5 @@ export * from './secret';
 export * from './token';
 export * from './utils';
 export * from './error-codes';
-export type { MintInfo } from './types';
 export * from './payment-request';
+export * from './mint-info';

--- a/app/lib/cashu/mint-info.ts
+++ b/app/lib/cashu/mint-info.ts
@@ -1,0 +1,178 @@
+/**
+ * This class was copied from cashu-ts v2.7.2 and extended with the following methods:
+ * - get iconUrl
+ * - get internalMeltsOnly
+ *
+ * As of cashu-ts v2.7.2, the MintInfo class is not exported, so we need to copy it here in order to extend it.
+ */
+
+import type {
+  GetInfoResponse,
+  MPPMethod,
+  SwapMethod,
+  WebSocketSupport,
+} from '@cashu/cashu-ts';
+
+/**
+ * A class that represents the data fetched from the mint's
+ * [NUT-06 info endpoint](https://github.com/cashubtc/nuts/blob/main/06.md)
+ */
+export class MintInfo {
+  private readonly _mintInfo: GetInfoResponse;
+  private readonly _protectedEnpoints?: {
+    cache: {
+      [url: string]: boolean;
+    };
+    apiReturn: Array<{
+      method: 'GET' | 'POST';
+      regex: RegExp;
+      cachedValue?: boolean;
+    }>;
+  };
+
+  constructor(info: GetInfoResponse) {
+    this._mintInfo = info;
+    if (info.nuts[22]) {
+      this._protectedEnpoints = {
+        cache: {},
+        apiReturn: info.nuts[22].protected_endpoints.map((o) => ({
+          method: o.method,
+          regex: new RegExp(o.path),
+        })),
+      };
+    }
+  }
+
+  isSupported(num: 4 | 5): { disabled: boolean; params: SwapMethod[] };
+  isSupported(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20): { supported: boolean };
+  isSupported(num: 17): { supported: boolean; params?: WebSocketSupport[] };
+  isSupported(num: 15): { supported: boolean; params?: MPPMethod[] };
+  isSupported(num: number) {
+    switch (num) {
+      case 4:
+      case 5: {
+        return this.checkMintMelt(num);
+      }
+      case 7:
+      case 8:
+      case 9:
+      case 10:
+      case 11:
+      case 12:
+      case 14:
+      case 20: {
+        return this.checkGenericNut(num);
+      }
+      case 17: {
+        return this.checkNut17();
+      }
+      case 15: {
+        return this.checkNut15();
+      }
+      default: {
+        throw new Error('nut is not supported by cashu-ts');
+      }
+    }
+  }
+
+  requiresBlindAuthToken(path: string) {
+    if (!this._protectedEnpoints) {
+      return false;
+    }
+    if (typeof this._protectedEnpoints.cache[path] === 'boolean') {
+      return this._protectedEnpoints.cache[path];
+    }
+    const isProtectedEndpoint = this._protectedEnpoints.apiReturn.some((e) =>
+      e.regex.test(path),
+    );
+    this._protectedEnpoints.cache[path] = isProtectedEndpoint;
+    return isProtectedEndpoint;
+  }
+
+  private checkGenericNut(num: 7 | 8 | 9 | 10 | 11 | 12 | 14 | 20) {
+    if (this._mintInfo.nuts[num]?.supported) {
+      return { supported: true };
+    }
+    return { supported: false };
+  }
+  private checkMintMelt(num: 4 | 5) {
+    const mintMeltInfo = this._mintInfo.nuts[num];
+    if (
+      mintMeltInfo &&
+      mintMeltInfo.methods.length > 0 &&
+      !mintMeltInfo.disabled
+    ) {
+      return { disabled: false, params: mintMeltInfo.methods };
+    }
+    return { disabled: true, params: mintMeltInfo.methods };
+  }
+  private checkNut17() {
+    if (
+      this._mintInfo.nuts[17] &&
+      this._mintInfo.nuts[17].supported.length > 0
+    ) {
+      return { supported: true, params: this._mintInfo.nuts[17].supported };
+    }
+    return { supported: false };
+  }
+  private checkNut15() {
+    if (this._mintInfo.nuts[15] && this._mintInfo.nuts[15].methods.length > 0) {
+      return { supported: true, params: this._mintInfo.nuts[15].methods };
+    }
+    return { supported: false };
+  }
+
+  get contact() {
+    return this._mintInfo.contact;
+  }
+
+  get description() {
+    return this._mintInfo.description;
+  }
+
+  get description_long() {
+    return this._mintInfo.description_long;
+  }
+
+  get name() {
+    return this._mintInfo.name;
+  }
+
+  get pubkey() {
+    return this._mintInfo.pubkey;
+  }
+
+  get nuts() {
+    return this._mintInfo.nuts;
+  }
+
+  get version() {
+    return this._mintInfo.version;
+  }
+
+  get motd() {
+    return this._mintInfo.motd;
+  }
+
+  // Below methods are added in addition to what the cashu-ts MintInfo class provides
+
+  get iconUrl() {
+    return this._mintInfo.icon_url;
+  }
+
+  /**
+   * Whether the mint only allows internal melts.
+   *
+   * NOTE: This flag is not currently defined in the NUTs.
+   * Internal melts only is a feature that we have added to agicash mints
+   * for creating a closed-loop mint.
+   */
+  get internalMeltsOnly() {
+    const methods = this._mintInfo.nuts[5].methods as (SwapMethod & {
+      options?: { internal_melts_only?: boolean };
+    })[];
+    return methods.some(
+      (method) => method.options?.internal_melts_only === true,
+    );
+  }
+}

--- a/app/lib/cashu/mint-validation.ts
+++ b/app/lib/cashu/mint-validation.ts
@@ -1,10 +1,6 @@
 import type { MintKeyset, WebSocketSupport } from '@cashu/cashu-ts';
-import type {
-  CashuProtocolUnit,
-  MintInfo,
-  NUT,
-  NUT17WebSocketCommand,
-} from './types';
+import type { MintInfo } from './mint-info';
+import type { CashuProtocolUnit, NUT, NUT17WebSocketCommand } from './types';
 
 type NutValidationResult =
   | { isValid: false; message: string }

--- a/app/lib/cashu/types.ts
+++ b/app/lib/cashu/types.ts
@@ -1,4 +1,3 @@
-import type { CashuWallet } from '@cashu/cashu-ts';
 import { z } from 'zod';
 
 /**
@@ -139,12 +138,6 @@ export type ProofSecret =
  * @see https://github.com/cashubtc/nuts/blob/main/11.md for Pay-to-Pub-Key (P2PK) spending condition
  */
 export type P2PKSecret = NUT10Secret & { kind: 'P2PK' };
-
-/**
- * A class that represents the data fetched from the mint's
- * [NUT-06 info endpoint](https://github.com/cashubtc/nuts/blob/main/06.md)
- */
-export type MintInfo = Awaited<ReturnType<CashuWallet['getMintInfo']>>;
 
 /**
  * The units that are determined by the soft-consensus of cashu mints and wallets.

--- a/app/lib/cashu/utils.ts
+++ b/app/lib/cashu/utils.ts
@@ -9,6 +9,7 @@ import Big from 'big.js';
 import type { DistributedOmit } from 'type-fest';
 import { decodeBolt11 } from '~/lib/bolt11';
 import type { Currency, CurrencyUnit } from '../money';
+import { MintInfo } from './mint-info';
 import { sumProofs } from './proof';
 import type { CashuProtocolUnit } from './types';
 
@@ -83,13 +84,17 @@ export const getWalletCurrency = (wallet: CashuWallet) => {
  */
 export class ExtendedCashuWallet extends CashuWallet {
   private _bip39Seed: Uint8Array | undefined;
+  private _cachedMintInfo: MintInfo | undefined;
 
   constructor(
     mint: CashuMint,
-    options: ConstructorParameters<typeof CashuWallet>[1],
+    options?: ConstructorParameters<typeof CashuWallet>[1] & {
+      mintInfo?: MintInfo;
+    },
   ) {
     super(mint, options);
     this._bip39Seed = options?.bip39seed;
+    this._cachedMintInfo = options?.mintInfo;
   }
 
   get seed() {
@@ -97,6 +102,15 @@ export class ExtendedCashuWallet extends CashuWallet {
       throw new Error('Seed not set');
     }
     return this._bip39Seed;
+  }
+
+  get cachedMintInfo() {
+    if (!this._cachedMintInfo) {
+      throw new Error(
+        'Mint info not cached. Initialize the wallet with a MintInfo or call getMintInfo first.',
+      );
+    }
+    return this._cachedMintInfo;
   }
 
   /**
@@ -156,6 +170,15 @@ export class ExtendedCashuWallet extends CashuWallet {
     return fee;
   }
 
+  async getExtendedMintInfo() {
+    if (this._cachedMintInfo) {
+      return this._cachedMintInfo;
+    }
+    const info = new MintInfo(await this.mint.getInfo());
+    this._cachedMintInfo = info;
+    return info;
+  }
+
   private getMinNumberOfProofsForAmount(keys: Keys, amount: Big) {
     const availableDenominations = Object.keys(keys).map((x) => new Big(x));
     const biggestDenomination = availableDenominations.reduce(
@@ -205,6 +228,7 @@ export const getCashuWallet = (
     'unit'
   > & {
     unit?: CurrencyUnit;
+    mintInfo?: MintInfo;
   } = {},
 ) => {
   const { unit, ...rest } = options;


### PR DESCRIPTION
I'm doing this to prepare for the Loyalty Points PR. 

### 1. Extended MintInfo class with `internal_melts_only`
For loyalty points we will classify a mint based on whether the `internal_melts_only` flag is set. Cashu-ts obviously doesn't have this, so I copied the existing MintInfo class then added the necessary methods. This makes it easier to modify the expected mint info as we are running our own mints.

### 2. Cache mint info in CashuWallet

We already initialize our wallets with mint info, and for loyalty points, we read this `internal_melts_only` config a lot, so it seemed nice to make getting the mint info sync.

