### PR TITLE
introduce stars

### DIFF
--- a/app/features/accounts/account-hooks.ts
+++ b/app/features/accounts/account-hooks.ts
@@ -19,6 +19,7 @@ import {
   type CashuAccount,
   type ExtendedAccount,
   getAccountBalance,
+  isStarAccount,
 } from './account';
 import {
   type AccountRepository,
@@ -278,6 +279,8 @@ export const accountsQueryOptions = ({
 export function useAccounts<T extends AccountType = AccountType>(select?: {
   currency?: Currency;
   type?: T;
+  excludeStarAccounts?: boolean;
+  starAccountsOnly?: boolean;
 }): UseSuspenseQueryResult<ExtendedAccount<T>[]> {
   const user = useUser();
   const accountRepository = useAccountRepository();
@@ -302,13 +305,25 @@ export function useAccounts<T extends AccountType = AccountType>(select?: {
             if (select.type && account.type !== select.type) {
               return false;
             }
+            if (select.excludeStarAccounts && isStarAccount(account)) {
+              return false;
+            }
+            if (select.starAccountsOnly && !isStarAccount(account)) {
+              return false;
+            }
             return true;
           },
         );
 
         return filteredData;
       },
-      [select?.currency, select?.type, user],
+      [
+        select?.currency,
+        select?.type,
+        select?.excludeStarAccounts,
+        select?.starAccountsOnly,
+        user,
+      ],
     ),
   });
 }
@@ -431,14 +446,17 @@ export function useAddCashuAccount() {
   return mutateAsync;
 }
 
+/**
+ * @returns the total balance of all accounts for the given currency excluding Star accounts.
+ */
 export function useBalance(currency: Currency) {
-  const { data: accounts } = useAccounts({ currency });
-  const balance = accounts.reduce(
-    (acc, account) => {
-      const accountBalance = getAccountBalance(account);
-      return acc.add(accountBalance);
-    },
-    new Money({ amount: 0, currency }),
-  );
+  const { data: accounts } = useAccounts({
+    currency,
+    excludeStarAccounts: true,
+  });
+  const balance = accounts.reduce((acc, account) => {
+    const accountBalance = getAccountBalance(account);
+    return acc.add(accountBalance);
+  }, Money.zero(currency));
   return balance;
 }

--- a/app/features/accounts/account-icons.tsx
+++ b/app/features/accounts/account-icons.tsx
@@ -1,15 +1,17 @@
-import { LandmarkIcon, Zap } from 'lucide-react';
+import { LandmarkIcon, StarIcon, Zap } from 'lucide-react';
 import type { ReactNode } from 'react';
 import type { AccountType } from './account';
 
 const CashuIcon = () => <LandmarkIcon className="h-4 w-4" />;
 const NWCIcon = () => <Zap className="h-4 w-4" />;
+const StarsIcon = () => <StarIcon className="h-4 w-4" />;
 
-const iconsByAccountType: Record<AccountType, ReactNode> = {
+const iconsByAccountType: Record<AccountType | 'star', ReactNode> = {
   cashu: <CashuIcon />,
   nwc: <NWCIcon />,
+  star: <StarsIcon />,
 };
 
-export function AccountTypeIcon({ type }: { type: AccountType }) {
+export function AccountTypeIcon({ type }: { type: AccountType | 'star' }) {
   return iconsByAccountType[type];
 }

--- a/app/features/accounts/account-selector.tsx
+++ b/app/features/accounts/account-selector.tsx
@@ -12,6 +12,7 @@ import { ScrollArea } from '~/components/ui/scroll-area';
 import { cn } from '~/lib/utils';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import { type Account, getAccountBalance } from './account';
+import { isStarAccount } from './account';
 import { AccountTypeIcon } from './account-icons';
 
 export type AccountWithBadges<T extends Account = Account> = T & {
@@ -26,7 +27,7 @@ function AccountItem({ account }: { account: AccountWithBadges }) {
 
   return (
     <div className="flex w-full items-center gap-4 px-3 py-4">
-      <AccountTypeIcon type={account.type} />
+      <AccountTypeIcon type={isStarAccount(account) ? 'star' : account.type} />
       <div className="flex w-full flex-col justify-between gap-2 text-start">
         <span className="font-medium">{account.name}</span>
         <div className="flex items-center justify-between text-xs">

--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -57,3 +57,6 @@ export const getAccountBalance = (account: Account) => {
   // TODO: implement balance logic for other account types
   return new Money({ amount: 0, currency: account.currency });
 };
+
+export const isStarAccount = (account: Account) =>
+  account.type === 'cashu' && account.wallet.cachedMintInfo.internalMeltsOnly;

--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -6,7 +6,7 @@ import {
   getCashuUnit,
   getCashuWallet,
 } from '~/lib/cashu';
-import type { ExtendedCashuAccount } from '../accounts/account';
+import { type ExtendedCashuAccount, isStarAccount } from '../accounts/account';
 import {
   allMintKeysetsQueryOptions,
   cashuMintValidator,
@@ -198,8 +198,9 @@ export class ReceiveCashuTokenService {
     sourceAccount: CashuAccountWithTokenFlags,
     otherAccounts: CashuAccountWithTokenFlags[],
   ): CashuAccountWithTokenFlags[] {
-    if (sourceAccount.isTestMint) {
+    if (sourceAccount.isTestMint || isStarAccount(sourceAccount)) {
       // Tokens sourced from test mint can only be claimed to the same mint
+      // Tokens sourced from Star accounts cannot pay external invoices
       return sourceAccount.isSelectable ? [sourceAccount] : [];
     }
     return [sourceAccount, ...otherAccounts].filter(

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -208,7 +208,9 @@ export default function ReceiveToken({
               <AccountSelector
                 accounts={selectableAccounts}
                 selectedAccount={receiveAccount}
-                disabled={isCrossMintSwapDisabled}
+                disabled={
+                  isCrossMintSwapDisabled || selectableAccounts.length === 1
+                }
                 onSelect={setReceiveAccount}
               />
             </div>

--- a/app/features/settings/accounts/all-accounts.tsx
+++ b/app/features/settings/accounts/all-accounts.tsx
@@ -14,7 +14,10 @@ import type { Currency } from '~/lib/money';
 import { LinkWithViewTransition } from '~/lib/transitions';
 
 function CurrencyAccounts({ currency }: { currency: Currency }) {
-  const { data: accounts } = useAccounts({ currency });
+  const { data: accounts } = useAccounts({
+    currency,
+    excludeStarAccounts: true,
+  });
 
   return (
     <div className="space-y-3">

--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -18,6 +18,7 @@ import { useToast } from '~/hooks/use-toast';
 import { canShare, shareContent } from '~/lib/share';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { cn } from '~/lib/utils';
+import { isStarAccount } from '../accounts/account';
 import { useDefaultAccount } from '../accounts/account-hooks';
 import { AccountTypeIcon } from '../accounts/account-icons';
 import { ColorModeToggle } from '../theme/color-mode-toggle';
@@ -111,7 +112,9 @@ export default function Settings() {
         </SettingsNavButton>
 
         <SettingsNavButton to="/settings/accounts">
-          <AccountTypeIcon type={defaultAccount.type} />
+          <AccountTypeIcon
+            type={isStarAccount(defaultAccount) ? 'star' : defaultAccount.type}
+          />
           <span>{defaultAccount.name}</span>
         </SettingsNavButton>
 


### PR DESCRIPTION
depends on #658 

This introduces basic handling for star accounts. A star account is a cashu account with a mint that only allows internal melts.

- removed star accounts from account list
- removed star account balances from main balance and currency switcher balances
- added a new account icon for for `star`. 

> NOTE: that I decided not to make a new account type called `star` because its exactly the same as a cashu account with some minor changes in how they're handled in the UX. If we define a new `star` account, then everywhere we check if `account.type === 'cashu'` we also have to check if the type is `star`