### PR TITLE
Realtime fixes and improvements

### DIFF
--- a/app/lib/supabase/supabase-realtime-channel.ts
+++ b/app/lib/supabase/supabase-realtime-channel.ts
@@ -1,0 +1,36 @@
+import type { RealtimeChannel } from '@supabase/realtime-js';
+import type { SupabaseRealtimeManager } from './supabase-realtime-manager';
+
+/**
+ * A wrapper around Supabase RealtimeChannel subcribes and unsubscribes from the channel through the realtime manager.
+ */
+export class SupabaseRealtimeChannel {
+  constructor(
+    public readonly channelManager: SupabaseRealtimeManager,
+    private readonly underlyingChannel: RealtimeChannel,
+  ) {}
+
+  /**
+   * Gets the topic of the channel
+   */
+  public get topic(): string {
+    return this.underlyingChannel.topic;
+  }
+
+  /**
+   * Subscribes to the channel through the manager.
+   * @param onConnected A callback that is called when the channel is initially connected or reconnected.
+   * @returns A promise that resolves when the channel is subscribed or the subscription fails.
+   */
+  public async subscribe(onConnected?: () => void): Promise<void> {
+    await this.channelManager.subscribe(this.topic, onConnected);
+  }
+
+  /**
+   * Unsubscribes from the channel and removes it from the manager.
+   * @returns A promise that resolves when the channel is unsubscribed.
+   */
+  public async unsubscribe(): Promise<void> {
+    await this.channelManager.removeChannel(this.topic);
+  }
+}

--- a/app/lib/supabase/supabase-realtime-hooks.ts
+++ b/app/lib/supabase/supabase-realtime-hooks.ts
@@ -61,29 +61,29 @@ export function useSupabaseRealtime({
   const channelBuilderRef = useLatest(channelBuilder);
   const onConnectedRef = useLatest(onConnected);
 
-  const getSnapshot = useCallback(() => {
+  const getChannelStatus = useCallback(() => {
     const { topic, manager } = channelBuilderRef.current;
     return manager.getChannelStatus(topic) ?? 'idle';
   }, []);
 
-  const subscribeToTopicStatusChange = useCallback((listener: () => void) => {
+  const subscribeToChannelStatusChange = useCallback((listener: () => void) => {
     const { topic, manager } = channelBuilderRef.current;
-    return manager.subscribeToTopicStatusChange(topic, listener);
+    return manager.subscribeToChannelStatusChange(topic, listener);
   }, []);
 
   const status = useSyncExternalStore(
-    subscribeToTopicStatusChange,
-    getSnapshot,
+    subscribeToChannelStatusChange,
+    getChannelStatus,
   );
 
   useEffect(() => {
     const builder = channelBuilderRef.current;
     const { manager } = builder;
-    const { channel } = manager.addChannel(builder);
-    manager.subscribe(channel.topic, () => onConnectedRef.current?.());
+    const channel = manager.addChannel(builder);
+    channel.subscribe(() => onConnectedRef.current?.());
 
     return () => {
-      manager.removeChannel(channel.topic);
+      channel.unsubscribe();
     };
   }, []);
 


### PR DESCRIPTION
This fixes two bugs:
1. when channel error or timeout would happen on subscribed channel the retries wouldn't work because the status of the channel would still be subscribed and loop in processResubscribeQueue has this code:
```
if (!state || state.status === 'subscribed') {
   break;
}
```
this was fixed by introducing reconnecting status and moving to that when resubscribe is scheduled.

2. when useSupabaseRealtime would be mounted, unmounted and the mounted again in the short period of time for the same channel topic (like in react strict mode) we would mess up the channel because current version of useEffect doesn't synchronise to setup and cleanup for the same topic in any way. in this pr we introduce synchronisation via global maps that stores pending setup and cleanup promises maps. This makes it work like this:
a) component is mounted -> channel is created and subscription is triggered
b) component is unmounted -> cleanup fn waits for the subscription to finish before triggering channel removal 
c) subscription is done so cleanup fn know starts channel removal
d) component is mounted again -> setup fn waits for the pending cleanup to finish before creating and subscribing to the channel again

I am still thinking if this synchronisation logic should maybe go into the manager itself or it belongs to react hook like in this pr. I think I will merge this now to solve the bug and decide about that after