### PR TITLE
fix(send): don't crash the app shell when a mint rejects send initiation

### DIFF
--- a/apps/web-wallet/app/features/send/cashu-send-quote-hooks.ts
+++ b/apps/web-wallet/app/features/send/cashu-send-quote-hooks.ts
@@ -347,7 +347,7 @@ export function useProcessCashuSendQuoteTasks() {
       }
       return failureCount < 3;
     },
-    throwOnError: true,
+    throwOnError: (error) => !(error instanceof MintOperationError),
     onError: (error, variables) => {
       if (error instanceof MintOperationError) {
         console.warn('Failed to initiate send.', {


### PR DESCRIPTION
## What

Paying a Lightning invoice that the mint reports as **already paid** from a Cashu account replaced the whole app with the root error screen ("Oops, something went wrong — Invoice already paid."). The send itself was handled correctly — the quote was marked FAILED with the reason recorded — but the app shell still crashed.

## Why

The background `initiateSend` mutation in `cashu-send-quote-hooks.ts` pairs `throwOnError: true` with an `onError` that already resolves `MintOperationError` gracefully (`failSendQuote` records the failure reason). TanStack Query rethrows the error during render even when `onError` handled it, so it propagated from `TaskProcessor`'s render into the root `RenderErrorBoundary`.

Only reachable when the mint accepts a melt quote for an already-paid invoice and then rejects the melt itself (e.g. Testnut locally) — production mints typically refuse at quote creation, which is why this never surfaced. Pre-existing since the original cashu lightning sends commit (`8f02ce43`, April 2025); unrelated to the wallet-sdk extraction (#1162), where the mutation is byte-identical.

## Fix

Make the rethrow conditional: skip only `MintOperationError` (mirroring the existing `retry` predicate), keep crashing loudly on unexpected errors.

## Verified

Reproduced and verified live by @pmilic021 against a local mint: paying an already-paid invoice now resolves to a FAILED transaction (reason "Invoice already paid." recorded) with the app staying usable, instead of the error screen.

Note: the recorded failure reason is not displayed anywhere in the UI (true for all flows — reasons are write-only today). Surfacing `failureReason` on the transaction details screen is a possible follow-up, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)