### PR TITLE
fix(wallet-sdk): session-lifecycle hardening — consumer fences, revocable key capability, terminal dispose

### DIFF
--- a/apps/web-wallet/app/features/shared/cashu-query-options.ts
+++ b/apps/web-wallet/app/features/shared/cashu-query-options.ts
@@ -7,10 +7,11 @@ import {
   getMintInfo,
 } from '@agicash/wallet-sdk/temporary';
 import { type QueryClient, queryOptions } from '@tanstack/react-query';
+import { derivedKeyQueryPrefix } from './session-key-queries';
 
 export const seedQueryOptions = () =>
   queryOptions({
-    queryKey: ['cashu-seed'],
+    queryKey: [derivedKeyQueryPrefix, 'cashu-seed'],
     queryFn: () => getCashuSeed(),
     staleTime: Number.POSITIVE_INFINITY,
   });
@@ -20,7 +21,7 @@ export const xpubQueryOptions = ({
   derivationPath,
 }: { queryClient: QueryClient; derivationPath?: string }) =>
   queryOptions({
-    queryKey: ['cashu-xpub', derivationPath],
+    queryKey: [derivedKeyQueryPrefix, 'cashu-xpub', derivationPath],
     queryFn: async () =>
       deriveCashuXpub(
         await queryClient.fetchQuery(seedQueryOptions()),
@@ -33,7 +34,7 @@ const privateKeyQueryOptions = ({
   derivationPath,
 }: { derivationPath?: string } = {}) =>
   queryOptions({
-    queryKey: ['cashu-private-key', derivationPath],
+    queryKey: [derivedKeyQueryPrefix, 'cashu-private-key', derivationPath],
     queryFn: () => getCashuPrivateKey(derivationPath),
     staleTime: Number.POSITIVE_INFINITY,
   });

--- a/apps/web-wallet/app/features/shared/encryption-hooks.ts
+++ b/apps/web-wallet/app/features/shared/encryption-hooks.ts
@@ -1,6 +1,9 @@
 import type { Encryption } from '@agicash/wallet-sdk/temporary';
 import {
-  getEncryption,
+  decryptBatchWithPrivateKey,
+  decryptWithPrivateKey,
+  encryptBatchToPublicKey,
+  encryptToPublicKey,
   readEncryptionPrivateKey,
   readEncryptionPublicKey,
 } from '@agicash/wallet-sdk/temporary';
@@ -9,13 +12,27 @@ import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 export const encryptionQueryOptions = () =>
   queryOptions({
     queryKey: ['encryption'],
-    // Derives then wraps in one step so the raw private-key bytes are never
-    // stored in the query cache — only the encrypt/decrypt closures are.
-    queryFn: async () =>
-      getEncryption(
-        await readEncryptionPrivateKey(),
-        await readEncryptionPublicKey(),
-      ),
+    // Derives then wraps so the raw private-key bytes are never stored in the
+    // query cache — only the encrypt/decrypt closures that capture them are.
+    // TEMPORARY: duplicates the SDK session-key facade's construction
+    // (packages/wallet-sdk/domain/sdk/session-keys.ts builds the same object
+    // literal from these primitives). Deleted at step 18 when receive/send/claim
+    // migrate into the SDK and this query is removed.
+    queryFn: async (): Promise<Encryption> => {
+      const privateKey = await readEncryptionPrivateKey();
+      const publicKeyHex = await readEncryptionPublicKey();
+      return {
+        encrypt: async <T = unknown>(data: T) =>
+          encryptToPublicKey(data, publicKeyHex),
+        decrypt: async <T = unknown>(data: string) =>
+          decryptWithPrivateKey<T>(data, privateKey),
+        encryptBatch: async <T extends readonly unknown[]>(data: T) =>
+          encryptBatchToPublicKey(data, publicKeyHex),
+        decryptBatch: async <T extends readonly unknown[]>(
+          data: readonly [...{ [K in keyof T]: string }],
+        ) => decryptBatchWithPrivateKey<T>(data, privateKey),
+      };
+    },
     staleTime: Number.POSITIVE_INFINITY,
   });
 

--- a/apps/web-wallet/app/features/shared/encryption-hooks.ts
+++ b/apps/web-wallet/app/features/shared/encryption-hooks.ts
@@ -8,10 +8,11 @@ import {
   readEncryptionPublicKey,
 } from '@agicash/wallet-sdk/temporary';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
+import { derivedKeyQueryPrefix } from './session-key-queries';
 
 export const encryptionQueryOptions = () =>
   queryOptions({
-    queryKey: ['encryption'],
+    queryKey: [derivedKeyQueryPrefix, 'encryption'],
     // Derives then wraps so the raw private-key bytes are never stored in the
     // query cache — only the encrypt/decrypt closures that capture them are.
     // TEMPORARY: duplicates the SDK session-key facade's construction

--- a/apps/web-wallet/app/features/shared/session-key-queries.test.ts
+++ b/apps/web-wallet/app/features/shared/session-key-queries.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'bun:test';
+import { QueryClient } from '@tanstack/react-query';
+import { evictDerivedKeyQueries } from './session-key-queries';
+
+describe('evictDerivedKeyQueries', () => {
+  it('drops every derived-key query (including derivation-path variants) and leaves others', () => {
+    const queryClient = new QueryClient();
+    const derivedKeys = [
+      ['encryption'],
+      ['cashu-seed'],
+      ['cashu-xpub', "m/0'"],
+      ['cashu-private-key', "m/0'"],
+      ['spark-mnemonic'],
+    ];
+    for (const queryKey of derivedKeys) {
+      queryClient.setQueryData(queryKey, 'previous-user');
+    }
+    // An unrelated query must survive the eviction.
+    queryClient.setQueryData(['auth-state'], 'keep');
+
+    evictDerivedKeyQueries(queryClient);
+
+    for (const queryKey of derivedKeys) {
+      expect(queryClient.getQueryData(queryKey)).toBeUndefined();
+    }
+    expect(queryClient.getQueryData<string>(['auth-state'])).toBe('keep');
+  });
+});

--- a/apps/web-wallet/app/features/shared/session-key-queries.test.ts
+++ b/apps/web-wallet/app/features/shared/session-key-queries.test.ts
@@ -1,21 +1,29 @@
 import { describe, expect, it } from 'bun:test';
 import { QueryClient } from '@tanstack/react-query';
-import { evictDerivedKeyQueries } from './session-key-queries';
+import { seedQueryOptions, xpubQueryOptions } from './cashu-query-options';
+import { encryptionQueryOptions } from './encryption-hooks';
+import {
+  derivedKeyQueryPrefix,
+  evictDerivedKeyQueries,
+} from './session-key-queries';
+import { sparkMnemonicQueryOptions } from './spark-query-options';
 
 describe('evictDerivedKeyQueries', () => {
-  it('drops every derived-key query (including derivation-path variants) and leaves others', () => {
+  it('drops every derived-key query under the shared prefix (incl. derivation-path variants) in one removeQueries, and leaves others', () => {
     const queryClient = new QueryClient();
+    // The five derived-key queries, each under the shared prefix, mirroring the
+    // shapes the query defs produce (two carry a derivation-path segment).
     const derivedKeys = [
-      ['encryption'],
-      ['cashu-seed'],
-      ['cashu-xpub', "m/0'"],
-      ['cashu-private-key', "m/0'"],
-      ['spark-mnemonic'],
+      [derivedKeyQueryPrefix, 'encryption'],
+      [derivedKeyQueryPrefix, 'cashu-seed'],
+      [derivedKeyQueryPrefix, 'cashu-xpub', "m/0'"],
+      [derivedKeyQueryPrefix, 'cashu-private-key', "m/0'"],
+      [derivedKeyQueryPrefix, 'spark-mnemonic'],
     ];
     for (const queryKey of derivedKeys) {
       queryClient.setQueryData(queryKey, 'previous-user');
     }
-    // An unrelated query must survive the eviction.
+    // A non-derived query must survive the prefix eviction.
     queryClient.setQueryData(['auth-state'], 'keep');
 
     evictDerivedKeyQueries(queryClient);
@@ -24,5 +32,25 @@ describe('evictDerivedKeyQueries', () => {
       expect(queryClient.getQueryData(queryKey)).toBeUndefined();
     }
     expect(queryClient.getQueryData<string>(['auth-state'])).toBe('keep');
+  });
+});
+
+describe('derived-key query defs', () => {
+  it('key every derived-key query under the shared prefix, so evictDerivedKeyQueries drops them', () => {
+    // Asserts the defs themselves adopt the prefix: a def regressing to a bare
+    // key — a silent cache-key mismatch typecheck cannot catch — fails here, not
+    // only in the grep gate. Covers the cashu-xpub derivation-path variant both
+    // with and without a path.
+    const queryClient = new QueryClient();
+    const derivedKeyDefs = [
+      encryptionQueryOptions().queryKey,
+      seedQueryOptions().queryKey,
+      xpubQueryOptions({ queryClient, derivationPath: "m/0'" }).queryKey,
+      xpubQueryOptions({ queryClient }).queryKey,
+      sparkMnemonicQueryOptions().queryKey,
+    ];
+    for (const queryKey of derivedKeyDefs) {
+      expect(queryKey[0]).toBe(derivedKeyQueryPrefix);
+    }
   });
 });

--- a/apps/web-wallet/app/features/shared/session-key-queries.ts
+++ b/apps/web-wallet/app/features/shared/session-key-queries.ts
@@ -1,0 +1,22 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+// The derived-key queries — encryption, cashu seed/xpub/private-key, and spark
+// mnemonic — cache Open Secret derivations with an infinity stale time. A
+// cross-user login without a prior sign-out (sign-out clears the whole cache)
+// must evict them so the next user re-derives, rather than reading — or being
+// left holding a revoked — previous session's key material. Prefixes evict the
+// parameterized derivation-path variants too.
+const derivedKeyQueryKeys = [
+  ['encryption'],
+  ['cashu-seed'],
+  ['cashu-xpub'],
+  ['cashu-private-key'],
+  ['spark-mnemonic'],
+];
+
+/** Drops every cached derived-key query so the next session derives fresh. */
+export const evictDerivedKeyQueries = (queryClient: QueryClient): void => {
+  for (const queryKey of derivedKeyQueryKeys) {
+    queryClient.removeQueries({ queryKey });
+  }
+};

--- a/apps/web-wallet/app/features/shared/session-key-queries.ts
+++ b/apps/web-wallet/app/features/shared/session-key-queries.ts
@@ -1,22 +1,19 @@
 import type { QueryClient } from '@tanstack/react-query';
 
-// The derived-key queries — encryption, cashu seed/xpub/private-key, and spark
-// mnemonic — cache Open Secret derivations with an infinity stale time. A
-// cross-user login without a prior sign-out (sign-out clears the whole cache)
-// must evict them so the next user re-derives, rather than reading — or being
-// left holding a revoked — previous session's key material. Prefixes evict the
-// parameterized derivation-path variants too.
-const derivedKeyQueryKeys = [
-  ['encryption'],
-  ['cashu-seed'],
-  ['cashu-xpub'],
-  ['cashu-private-key'],
-  ['spark-mnemonic'],
-];
+// Shared head segment for every session-derived-key query — encryption, cashu
+// seed/xpub/private-key, and spark mnemonic — which cache Open Secret derivations
+// with an infinity stale time. Keying them all under this prefix lets one
+// partial-prefix removeQueries drop them (and any future derived-key query) on an
+// auth change, so a cross-user login can't read — or leave a consumer holding a
+// revoked — the previous session's key material. The query defs import this, so
+// the defs and the eviction share one source of truth.
+export const derivedKeyQueryPrefix = 'derived-key';
 
-/** Drops every cached derived-key query so the next session derives fresh. */
+/**
+ * Drops every cached derived-key query — a partial-prefix match on
+ * {@link derivedKeyQueryPrefix}, so the parameterized derivation-path variants go
+ * too — so the next session derives fresh.
+ */
 export const evictDerivedKeyQueries = (queryClient: QueryClient): void => {
-  for (const queryKey of derivedKeyQueryKeys) {
-    queryClient.removeQueries({ queryKey });
-  }
+  queryClient.removeQueries({ queryKey: [derivedKeyQueryPrefix] });
 };

--- a/apps/web-wallet/app/features/shared/spark-query-options.ts
+++ b/apps/web-wallet/app/features/shared/spark-query-options.ts
@@ -1,9 +1,10 @@
 import { getSparkMnemonic } from '@agicash/wallet-sdk/temporary';
 import { queryOptions } from '@tanstack/react-query';
+import { derivedKeyQueryPrefix } from './session-key-queries';
 
 export const sparkMnemonicQueryOptions = () =>
   queryOptions({
-    queryKey: ['spark-mnemonic'],
+    queryKey: [derivedKeyQueryPrefix, 'spark-mnemonic'],
     queryFn: () => getSparkMnemonic(),
     staleTime: Number.POSITIVE_INFINITY,
   });

--- a/apps/web-wallet/app/features/user/auth.ts
+++ b/apps/web-wallet/app/features/user/auth.ts
@@ -15,6 +15,7 @@ import {
 } from '~/features/shared/feature-flags';
 import { getQueryClient } from '~/features/shared/query-client';
 import { sdk } from '~/features/shared/sdk.client';
+import { evictDerivedKeyQueries } from '~/features/shared/session-key-queries';
 import { useLatest } from '~/lib/use-latest';
 import { oauthLoginSessionStorage } from './oauth-login-session-storage';
 import { sessionHintCookie } from './session-hint-cookie';
@@ -192,6 +193,9 @@ export const useAuthActions = (): AuthActions => {
 
   const refreshSession = useCallback(
     async (redirectTo?: string) => {
+      // A login can switch users without a prior sign-out; drop the previous
+      // user's infinity-stale derived keys so the next reads derive fresh.
+      evictDerivedKeyQueries(getQueryClient());
       await invalidateAuthQueries();
       if (redirectTo) {
         await navigate(redirectTo);

--- a/apps/web-wallet/app/features/user/auth.ts
+++ b/apps/web-wallet/app/features/user/auth.ts
@@ -120,6 +120,10 @@ export const authQueryOptions = () =>
  */
 export const invalidateAuthQueries = async () => {
   const queryClient = getQueryClient();
+  // Auth changed ⇒ drop the previous user's infinity-stale derived keys so the
+  // next read re-derives under the new session. Every auth-change path funnels
+  // through here, so the eviction lives at this choke point, not each call site.
+  evictDerivedKeyQueries(queryClient);
   await Promise.all([
     queryClient.invalidateQueries({
       queryKey: [authStateQueryKey],
@@ -193,9 +197,8 @@ export const useAuthActions = (): AuthActions => {
 
   const refreshSession = useCallback(
     async (redirectTo?: string) => {
-      // A login can switch users without a prior sign-out; drop the previous
-      // user's infinity-stale derived keys so the next reads derive fresh.
-      evictDerivedKeyQueries(getQueryClient());
+      // invalidateAuthQueries drops the previous user's derived keys (a login can
+      // switch users without a prior sign-out), so no separate eviction here.
       await invalidateAuthQueries();
       if (redirectTo) {
         await navigate(redirectTo);

--- a/packages/wallet-sdk/domain/accounts/account-service.ts
+++ b/packages/wallet-sdk/domain/accounts/account-service.ts
@@ -5,7 +5,6 @@ import {
 } from '@agicash/cashu';
 import { Mint } from '@cashu/cashu-ts';
 import type { DistributedOmit } from 'type-fest';
-import { SessionEndedError } from '../../lib/error';
 import type { CashuAccount } from './account';
 import type { AccountRepository } from './account-repository';
 
@@ -43,12 +42,6 @@ export class AccountService {
       if (activeKeyset) {
         expiresAt = getKeysetExpiry(activeKeyset)?.toISOString() ?? null;
       }
-    }
-
-    // The offer-path mint fetch above isn't cancellable; if the session ended
-    // during it, don't issue the create for a session that no longer owns it.
-    if (options?.abortSignal?.aborted) {
-      throw new SessionEndedError();
     }
 
     return this.accountRepository.create<CashuAccount>(

--- a/packages/wallet-sdk/domain/accounts/account-service.ts
+++ b/packages/wallet-sdk/domain/accounts/account-service.ts
@@ -5,31 +5,35 @@ import {
 } from '@agicash/cashu';
 import { Mint } from '@cashu/cashu-ts';
 import type { DistributedOmit } from 'type-fest';
+import { SessionEndedError } from '../../lib/error';
 import type { CashuAccount } from './account';
 import type { AccountRepository } from './account-repository';
 
 export class AccountService {
   constructor(private readonly accountRepository: AccountRepository) {}
 
-  async addCashuAccount({
-    userId,
-    account,
-  }: {
-    userId: string;
-    account: DistributedOmit<
-      CashuAccount,
-      | 'id'
-      | 'createdAt'
-      | 'expiresAt'
-      | 'isTestMint'
-      | 'keysetCounters'
-      | 'proofs'
-      | 'version'
-      | 'wallet'
-      | 'isOnline'
-      | 'state'
-    >;
-  }) {
+  async addCashuAccount(
+    {
+      userId,
+      account,
+    }: {
+      userId: string;
+      account: DistributedOmit<
+        CashuAccount,
+        | 'id'
+        | 'createdAt'
+        | 'expiresAt'
+        | 'isTestMint'
+        | 'keysetCounters'
+        | 'proofs'
+        | 'version'
+        | 'wallet'
+        | 'isOnline'
+        | 'state'
+      >;
+    },
+    options?: { abortSignal?: AbortSignal },
+  ) {
     const isTestMint = checkIsTestMint(account.mintUrl);
 
     let expiresAt: string | null = null;
@@ -41,12 +45,21 @@ export class AccountService {
       }
     }
 
-    return this.accountRepository.create<CashuAccount>({
-      ...account,
-      userId,
-      isTestMint,
-      expiresAt,
-      keysetCounters: {},
-    });
+    // The offer-path mint fetch above isn't cancellable; if the session ended
+    // during it, don't issue the create for a session that no longer owns it.
+    if (options?.abortSignal?.aborted) {
+      throw new SessionEndedError();
+    }
+
+    return this.accountRepository.create<CashuAccount>(
+      {
+        ...account,
+        userId,
+        isTestMint,
+        expiresAt,
+        keysetCounters: {},
+      },
+      options,
+    );
   }
 }

--- a/packages/wallet-sdk/domain/accounts/accounts-api.test.ts
+++ b/packages/wallet-sdk/domain/accounts/accounts-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { Money } from '@agicash/money';
 import type { AgicashDb } from '../../db/database';
-import { NoSessionError } from '../../lib/error';
+import { NoSessionError, SessionEndedError } from '../../lib/error';
 import type { SparkWalletConfig } from '../../lib/spark/wallet';
 import type { AddCashuAccountParams, AuthSession, AuthUser } from '../sdk';
 import { createSessionKeys } from '../sdk/session-keys';
@@ -125,6 +125,39 @@ describe('createAccountsApi', () => {
         }),
       ).rejects.toBeInstanceOf(NoSessionError);
     });
+
+    it('rejects with SessionEndedError and creates nothing when the session ends before the write', async () => {
+      const keys = createSessionKeys();
+      let createCalls = 0;
+      const { api } = createAccountsApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        sparkConfig: {
+          storageDir: '.',
+          apiKey: 'k',
+        } satisfies SparkWalletConfig,
+        getSession: () => loggedIn('user-x'),
+        createRepository: async () => {
+          keys.reset();
+          return {
+            create: (async () => {
+              createCalls += 1;
+              return cashuDomain();
+            }) as unknown as AccountRepository['create'],
+          } as unknown as AccountRepository;
+        },
+      });
+
+      await expect(
+        api.cashu.add({
+          name: 'My mint',
+          mintUrl: 'https://testnut.cashu.space',
+          currency: 'BTC',
+          purpose: 'transactional',
+        }),
+      ).rejects.toBeInstanceOf(SessionEndedError);
+      expect(createCalls).toBe(0);
+    });
   });
 
   describe('list', () => {
@@ -153,6 +186,56 @@ describe('createAccountsApi', () => {
     it('throws NoSessionError without a session', async () => {
       const { api } = makeApi({ session: { isLoggedIn: false } });
       await expect(api.list()).rejects.toBeInstanceOf(NoSessionError);
+    });
+
+    it('rejects with SessionEndedError and issues no read when the session ends before the read', async () => {
+      const keys = createSessionKeys();
+      let getAllActiveCalls = 0;
+      const { api } = createAccountsApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        sparkConfig: {
+          storageDir: '.',
+          apiKey: 'k',
+        } satisfies SparkWalletConfig,
+        getSession: () => loggedIn('user-x'),
+        createRepository: async () => {
+          // The session ends between the signal capture and the read.
+          keys.reset();
+          return {
+            getAllActive: (async () => {
+              getAllActiveCalls += 1;
+              return [];
+            }) as unknown as AccountRepository['getAllActive'],
+          } as unknown as AccountRepository;
+        },
+      });
+
+      await expect(api.list()).rejects.toBeInstanceOf(SessionEndedError);
+      expect(getAllActiveCalls).toBe(0);
+    });
+
+    it('rejects with SessionEndedError when the session ends while the read hydrates', async () => {
+      const keys = createSessionKeys();
+      const { api } = createAccountsApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        sparkConfig: {
+          storageDir: '.',
+          apiKey: 'k',
+        } satisfies SparkWalletConfig,
+        getSession: () => loggedIn('user-x'),
+        createRepository: async () =>
+          ({
+            getAllActive: (async () => {
+              // The session ends while the repository hydrates the rows.
+              keys.reset();
+              return [] as DomainAccount[];
+            }) as unknown as AccountRepository['getAllActive'],
+          }) as unknown as AccountRepository,
+      });
+
+      await expect(api.list()).rejects.toBeInstanceOf(SessionEndedError);
     });
   });
 

--- a/packages/wallet-sdk/domain/accounts/accounts-api.ts
+++ b/packages/wallet-sdk/domain/accounts/accounts-api.ts
@@ -1,5 +1,5 @@
 import type { AgicashDb } from '../../db/database';
-import { NoSessionError } from '../../lib/error';
+import { NoSessionError, SessionEndedError } from '../../lib/error';
 import type { SparkWalletConfig } from '../../lib/spark/wallet';
 import type { AccountsApi, AuthSession, CashuAccount } from '../sdk';
 import type { SessionKeys } from '../sdk/session-keys';
@@ -49,23 +49,52 @@ export function createAccountsApi(deps: Deps): {
     getRepository,
     api: {
       get: async (id) => {
+        const signal = deps.keys.sessionSignal();
         const repository = await getRepository();
-        return repository.get(id);
+        if (signal.aborted) {
+          throw new SessionEndedError();
+        }
+        const account = await repository.get(id, { abortSignal: signal });
+        if (signal.aborted) {
+          throw new SessionEndedError();
+        }
+        return account;
       },
       list: async () => {
         const userId = requireUserId();
+        const signal = deps.keys.sessionSignal();
         const repository = await getRepository();
-        return repository.getAllActive(userId);
+        if (signal.aborted) {
+          throw new SessionEndedError();
+        }
+        const accounts = await repository.getAllActive(userId, {
+          abortSignal: signal,
+        });
+        if (signal.aborted) {
+          throw new SessionEndedError();
+        }
+        return accounts;
       },
       cashu: {
         add: async (params): Promise<CashuAccount> => {
           const userId = requireUserId();
+          const signal = deps.keys.sessionSignal();
           const repository = await getRepository();
+          if (signal.aborted) {
+            throw new SessionEndedError();
+          }
           const service = new AccountService(repository);
-          return service.addCashuAccount({
-            userId,
-            account: { ...params, type: 'cashu' },
-          });
+          const account = await service.addCashuAccount(
+            {
+              userId,
+              account: { ...params, type: 'cashu' },
+            },
+            { abortSignal: signal },
+          );
+          if (signal.aborted) {
+            throw new SessionEndedError();
+          }
+          return account;
         },
       },
     },

--- a/packages/wallet-sdk/domain/sdk/sdk.ts
+++ b/packages/wallet-sdk/domain/sdk/sdk.ts
@@ -2,6 +2,7 @@ import * as openSecret from '@agicash/opensecret';
 import type {
   AccountsApi,
   AuthApi,
+  AuthSession,
   ContactsApi,
   FeatureFlagsApi,
   ReceiveApi,
@@ -17,7 +18,7 @@ import type {
 import { createAgicashDbClient } from '../../db/client';
 import { createSupabaseSessionTokenGetter } from '../../db/supabase-session';
 import { clearAgicashMintAuthToken } from '../../lib/agicash-mint-auth-provider';
-import { NotImplementedError } from '../../lib/error';
+import { DisposedError, NotImplementedError } from '../../lib/error';
 import { generateRandomPassword } from '../../lib/password';
 import {
   type SparkWalletConfig,
@@ -27,7 +28,7 @@ import { createAccountsApi } from '../accounts/accounts-api';
 import { AuthService } from '../user/auth-service';
 import { createUserApi } from '../user/user-api';
 import { WalletEventEmitter } from './events';
-import { createSessionKeys } from './session-keys';
+import { type OwnedSessionKeys, createSessionKeys } from './session-keys';
 
 // The current instance: the instance currently constructed and not yet
 // disposed. Makes the one-instance-per-process constraint (see the constructor
@@ -69,6 +70,8 @@ export class AgicashSdk implements Sdk {
   }
 
   private readonly authService: AuthService;
+  private readonly keys: OwnedSessionKeys;
+  private disposed = false;
 
   private constructor(config: SdkConfig) {
     // The Open Secret client is module-scoped in @agicash/opensecret, so auth
@@ -84,6 +87,7 @@ export class AgicashSdk implements Sdk {
     const events = new WalletEventEmitter(config.logger);
 
     const keys = createSessionKeys();
+    this.keys = keys;
 
     // Created before authService — the isLoggedIn closure dereferences it
     // lazily at request time, after the constructor has assigned it.
@@ -113,6 +117,16 @@ export class AgicashSdk implements Sdk {
       logger: config.logger,
     });
 
+    // The namespaces read the session through this, not the public
+    // auth.getSession(): a call on a namespace handle retained across dispose()
+    // rejects instead of acting on the dead instance's last session snapshot.
+    const getLiveSession = (): AuthSession => {
+      if (this.disposed) {
+        throw new DisposedError();
+      }
+      return this.authService.getSession();
+    };
+
     const db = createAgicashDbClient({
       url: config.db.url,
       anonKey: config.db.anonKey,
@@ -125,7 +139,7 @@ export class AgicashSdk implements Sdk {
     };
     const accounts = createAccountsApi({
       db,
-      getSession: () => this.authService.getSession(),
+      getSession: getLiveSession,
       keys,
       sparkConfig,
     });
@@ -133,7 +147,7 @@ export class AgicashSdk implements Sdk {
     this.auth = this.authService;
     this.user = createUserApi({
       db,
-      getSession: () => this.authService.getSession(),
+      getSession: getLiveSession,
       keys,
       getAccountRepository: accounts.getRepository,
     });
@@ -163,7 +177,9 @@ export class AgicashSdk implements Sdk {
   }
 
   async dispose(): Promise<void> {
+    this.disposed = true;
     this.authService.teardown();
+    this.keys.dispose();
     if (currentInstance === this) {
       currentInstance = undefined;
     }

--- a/packages/wallet-sdk/domain/sdk/session-keys.test.ts
+++ b/packages/wallet-sdk/domain/sdk/session-keys.test.ts
@@ -189,4 +189,29 @@ describe('createSessionKeys', () => {
       DisposedError,
     );
   });
+
+  it('revokes a retained encryption handle once its session ends', async () => {
+    const privateKey = new Uint8Array(32);
+    privateKey[31] = 1;
+    const publicKey =
+      '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+    const keys = createSessionKeys({
+      readEncryptionPrivateKey: async () => privateKey,
+      readEncryptionPublicKey: async () => publicKey,
+    });
+    const encryption = await keys.getEncryption();
+    const ciphertext = await encryption.encrypt({ owner: 'a' });
+
+    keys.reset();
+
+    // A handle retained across a session end (reset, not disposal) can't keep
+    // operating on the ended session's keys — it rejects rather than encrypting
+    // or decrypting under a key that no longer belongs to the live session.
+    await expect(encryption.encrypt({ owner: 'a' })).rejects.toBeInstanceOf(
+      SessionEndedError,
+    );
+    await expect(encryption.decrypt(ciphertext)).rejects.toBeInstanceOf(
+      SessionEndedError,
+    );
+  });
 });

--- a/packages/wallet-sdk/domain/sdk/session-keys.test.ts
+++ b/packages/wallet-sdk/domain/sdk/session-keys.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { BASE_CASHU_LOCKING_DERIVATION_PATH } from '../../lib/cashu';
 import { deriveCashuXpub } from '../../lib/cryptography';
+import { DisposedError, SessionEndedError } from '../../lib/error';
 import { createSessionKeys } from './session-keys';
 
 const seedA = new Uint8Array(64).fill(1);
@@ -54,7 +55,7 @@ describe('createSessionKeys', () => {
     );
   });
 
-  it('does not let a derivation in flight at reset populate the next session', async () => {
+  it('rejects an in-flight derivation whose session ended, and serves the next session fresh', async () => {
     let session: 'a' | 'b' = 'a';
     let releaseA: (value: string) => void = () => undefined;
     const gate = new Promise<string>((resolve) => {
@@ -70,11 +71,122 @@ describe('createSessionKeys', () => {
     keys.reset();
     releaseA('mnemonic a');
 
-    // The caller that started the fetch under session a still resolves to its
-    // own session's value...
-    expect(await inFlight).toBe('mnemonic a');
-    // ...but that stale resolution must not have populated the cache, so the
-    // next read derives session b fresh.
+    // The caller that started under session a must not receive a's key once a
+    // has ended — it rejects rather than resolving the stale value...
+    await expect(inFlight).rejects.toBeInstanceOf(SessionEndedError);
+    // ...and the stale resolution did not populate the cache, so the next read
+    // derives session b fresh.
     expect(await keys.getSparkMnemonic()).toBe('mnemonic b');
+  });
+
+  it('rejects getEncryption when the session ends between its two derivations', async () => {
+    let releasePublicKey: (value: string) => void = () => undefined;
+    const publicKeyGate = new Promise<string>((resolve) => {
+      releasePublicKey = resolve;
+    });
+    const keys = createSessionKeys({
+      readEncryptionPrivateKey: async () => new Uint8Array(32).fill(7),
+      readEncryptionPublicKey: () => publicKeyGate,
+    });
+
+    const pending = keys.getEncryption();
+    keys.reset();
+    releasePublicKey('public-key-a');
+
+    // A reset between the private- and public-key derivations would otherwise
+    // pair session a's private key with a later session's public key; the
+    // composite rejects instead of returning a mismatched pair.
+    await expect(pending).rejects.toBeInstanceOf(SessionEndedError);
+  });
+
+  it('rejects every getter terminally after dispose, so a retained handle cannot serve a disposed instance', async () => {
+    const keys = createSessionKeys({
+      readCashuSeed: async () => seedA,
+      readSparkMnemonic: async () => 'mnemonic a',
+    });
+    // Warm a memo: a plain reset would let this cached value keep resolving.
+    expect(await keys.getCashuSeed()).toBe(seedA);
+
+    keys.dispose();
+
+    await expect(keys.getCashuSeed()).rejects.toBeInstanceOf(DisposedError);
+    await expect(keys.getSparkMnemonic()).rejects.toBeInstanceOf(DisposedError);
+    await expect(keys.getEncryption()).rejects.toBeInstanceOf(DisposedError);
+  });
+
+  it('rejects a derivation in flight when dispose lands', async () => {
+    let releaseSeed: (value: Uint8Array) => void = () => undefined;
+    const gate = new Promise<Uint8Array>((resolve) => {
+      releaseSeed = resolve;
+    });
+    const keys = createSessionKeys({ readCashuSeed: () => gate });
+
+    const inFlight = keys.getCashuSeed();
+    keys.dispose();
+    releaseSeed(seedA);
+
+    await expect(inFlight).rejects.toBeInstanceOf(DisposedError);
+  });
+
+  it('exposes a session signal that aborts on reset and on dispose', () => {
+    const keys = createSessionKeys();
+
+    const firstSession = keys.sessionSignal();
+    expect(firstSession.aborted).toBe(false);
+
+    keys.reset();
+    expect(firstSession.aborted).toBe(true);
+
+    const secondSession = keys.sessionSignal();
+    expect(secondSession.aborted).toBe(false);
+
+    keys.dispose();
+    expect(secondSession.aborted).toBe(true);
+  });
+
+  it('rejects a getter reentered from a synchronous abort listener during reset', async () => {
+    const keys = createSessionKeys({ readCashuSeed: async () => seedA });
+    expect(await keys.getCashuSeed()).toBe(seedA);
+
+    let reentered: Promise<Uint8Array> | undefined;
+    keys.sessionSignal().addEventListener('abort', () => {
+      // reset() aborts the signal before it clears the memos; a getter reached
+      // from this synchronous listener must not hand back the ended session's
+      // cached key.
+      reentered = keys.getCashuSeed();
+    });
+
+    keys.reset();
+
+    expect(reentered).toBeDefined();
+    await expect(reentered).rejects.toBeInstanceOf(SessionEndedError);
+  });
+
+  it('revokes a retained encryption handle once its session is disposed', async () => {
+    const privateKey = new Uint8Array(32);
+    privateKey[31] = 1;
+    const publicKey =
+      '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+    const keys = createSessionKeys({
+      readEncryptionPrivateKey: async () => privateKey,
+      readEncryptionPublicKey: async () => publicKey,
+    });
+    const encryption = await keys.getEncryption();
+    // Works while the session is live.
+    const ciphertext = await encryption.encrypt({ owner: 'a' });
+    expect(await encryption.decrypt<{ owner: string }>(ciphertext)).toEqual({
+      owner: 'a',
+    });
+
+    keys.dispose();
+
+    // A handle retained across dispose can't keep operating on the dead
+    // session's keys.
+    await expect(encryption.encrypt({ owner: 'a' })).rejects.toBeInstanceOf(
+      DisposedError,
+    );
+    await expect(encryption.decrypt(ciphertext)).rejects.toBeInstanceOf(
+      DisposedError,
+    );
   });
 });

--- a/packages/wallet-sdk/domain/sdk/session-keys.ts
+++ b/packages/wallet-sdk/domain/sdk/session-keys.ts
@@ -5,7 +5,10 @@ import {
 import { deriveCashuXpub } from '../../lib/cryptography';
 import {
   type Encryption,
-  getEncryption,
+  decryptBatchWithPrivateKey,
+  decryptWithPrivateKey,
+  encryptBatchToPublicKey,
+  encryptToPublicKey,
   readEncryptionPrivateKey,
   readEncryptionPublicKey,
 } from '../../lib/encryption';
@@ -213,29 +216,50 @@ export function createSessionKeys(
         throw new SessionEndedError();
       }
       // The returned capability is revocable: raw key bytes copied out can't be,
-      // but this callable facade rejects once its session ends or the instance
-      // disposes, so a handle a host caches can't keep encrypting with a dead
-      // session's keys.
-      const encryption = getEncryption(privateKey, publicKey);
-      return new Proxy(encryption, {
-        get(target, property, receiver) {
-          const member = Reflect.get(target, property, receiver);
-          if (typeof member !== 'function') {
-            return member;
+      // but each method on this facade rejects once its session ends or the
+      // instance disposes, so a handle a host caches can't keep encrypting with a
+      // dead session's keys. Explicit methods (not a Proxy) keep the Encryption
+      // generic signatures intact for callers and delegate to the lib primitives.
+      return {
+        encrypt: async <T = unknown>(data: T) => {
+          if (disposed) {
+            return Promise.reject(new DisposedError());
           }
-          // Every Encryption method is async, so reject rather than throw: a
-          // revoked handle rejects its promise instead of throwing synchronously.
-          return (...args: unknown[]) => {
-            if (disposed) {
-              return Promise.reject(new DisposedError());
-            }
-            if (signal.aborted) {
-              return Promise.reject(new SessionEndedError());
-            }
-            return Reflect.apply(member, target, args);
-          };
+          if (signal.aborted) {
+            return Promise.reject(new SessionEndedError());
+          }
+          return encryptToPublicKey(data, publicKey);
         },
-      });
+        decrypt: async <T = unknown>(data: string) => {
+          if (disposed) {
+            return Promise.reject(new DisposedError());
+          }
+          if (signal.aborted) {
+            return Promise.reject(new SessionEndedError());
+          }
+          return decryptWithPrivateKey<T>(data, privateKey);
+        },
+        encryptBatch: async <T extends readonly unknown[]>(data: T) => {
+          if (disposed) {
+            return Promise.reject(new DisposedError());
+          }
+          if (signal.aborted) {
+            return Promise.reject(new SessionEndedError());
+          }
+          return encryptBatchToPublicKey(data, publicKey);
+        },
+        decryptBatch: async <T extends readonly unknown[]>(
+          data: readonly [...{ [K in keyof T]: string }],
+        ) => {
+          if (disposed) {
+            return Promise.reject(new DisposedError());
+          }
+          if (signal.aborted) {
+            return Promise.reject(new SessionEndedError());
+          }
+          return decryptBatchWithPrivateKey<T>(data, privateKey);
+        },
+      };
     },
     getEncryptionPublicKey: encryptionPublicKey.get,
     getCashuSeed: cashuSeed.get,

--- a/packages/wallet-sdk/domain/sdk/session-keys.ts
+++ b/packages/wallet-sdk/domain/sdk/session-keys.ts
@@ -9,6 +9,7 @@ import {
   readEncryptionPrivateKey,
   readEncryptionPublicKey,
 } from '../../lib/encryption';
+import { DisposedError, SessionEndedError } from '../../lib/error';
 import {
   getSparkIdentityPublicKeyFromMnemonic,
   getSparkMnemonic,
@@ -16,9 +17,11 @@ import {
 
 /**
  * The per-session key material the accounts and user namespaces derive from
- * Open Secret. Every getter is memoized for the life of the session and
- * cleared by {@link SessionKeys.reset}; a getter never resolves one user's key
- * into the next user's session.
+ * Open Secret. Every getter is memoized for the life of the session. A getter
+ * whose session ends before it resolves rejects with `SessionEndedError` rather
+ * than resolving one user's key into the next user's session, so a key-dependent
+ * operation rejects instead of running on a key that no longer belongs to the
+ * live session; a getter reached after disposal rejects with `DisposedError`.
  */
 export type SessionKeys = {
   /** ECIES encryption functions bound to the session's encryption keypair. */
@@ -33,8 +36,30 @@ export type SessionKeys = {
   getCashuLockingXpub(): Promise<string>;
   /** Spark identity public key, as persisted on the user row. */
   getSparkIdentityPublicKey(): Promise<string>;
+  /**
+   * The current session's abort signal. It aborts on {@link SessionKeys.reset}
+   * (a session end) and on disposal. A key-dependent operation captures it at
+   * its start and rejects if it aborts before the operation returns, so the
+   * operation rejects rather than resolving for a session that has ended.
+   * Cancellation of a DB write it threads the signal into is best-effort (a
+   * remote commit can still win the race); the guarantee is that no result is
+   * used, and no cross-session key material, for an ended session.
+   */
+  sessionSignal(): AbortSignal;
   /** Clears every memo. Call on session end so the next user derives fresh keys. */
   reset(): void;
+};
+
+/** {@link SessionKeys} plus the terminal teardown the owning SDK instance holds. */
+export type OwnedSessionKeys = SessionKeys & {
+  /**
+   * Terminal teardown, distinct from the reusable {@link SessionKeys.reset}:
+   * after it every getter rejects with `DisposedError`, an already-returned
+   * {@link Encryption} facade rejects, and no further derivation runs. Called on
+   * SDK dispose so a capability retained across disposal can't serve a dead
+   * instance's keys.
+   */
+  dispose(): void;
 };
 
 /**
@@ -49,13 +74,20 @@ type SessionKeysDeps = {
 };
 
 /**
- * Memoizes an async derivation for the life of a session. A derivation started
- * before a session ends belongs to that ended session: it captures the session
- * scope's abort signal when it begins, and once that signal is aborted its
- * result neither populates the cache nor releases the in-flight slot the next
- * session owns. A rejection is not cached, so a retry can recover.
+ * Memoizes an async derivation for the life of a session. Every call checks the
+ * current session signal before serving a cached value, so a getter reached
+ * while the session is aborted — including reentrantly, from a synchronous abort
+ * listener during {@link SessionKeys.reset} before the memos are cleared —
+ * rejects with `SessionEndedError` instead of returning stale key material. A
+ * derivation in flight when its session ends likewise rejects rather than
+ * resolving to its caller; a rejection is not cached, so a retry can recover.
+ * A getter reached after disposal rejects with `DisposedError`.
  */
-function createMemo<T>(fetcher: () => Promise<T>, getScope: () => AbortSignal) {
+function createMemo<T>(
+  fetcher: () => Promise<T>,
+  getSignal: () => AbortSignal,
+  isDisposed: () => boolean,
+) {
   let cached: { value: T } | undefined;
   let inFlight: Promise<T> | undefined;
 
@@ -65,20 +97,30 @@ function createMemo<T>(fetcher: () => Promise<T>, getScope: () => AbortSignal) {
       inFlight = undefined;
     },
     get: (): Promise<T> => {
+      if (isDisposed()) {
+        return Promise.reject(new DisposedError());
+      }
+      const signal = getSignal();
+      if (signal.aborted) {
+        return Promise.reject(new SessionEndedError());
+      }
       if (cached) {
         return Promise.resolve(cached.value);
       }
       if (!inFlight) {
-        const scope = getScope();
         inFlight = (async () => {
           try {
             const value = await fetcher();
-            if (!scope.aborted) {
-              cached = { value };
+            if (isDisposed()) {
+              throw new DisposedError();
             }
+            if (signal.aborted) {
+              throw new SessionEndedError();
+            }
+            cached = { value };
             return value;
           } finally {
-            if (!scope.aborted) {
+            if (!signal.aborted) {
               inFlight = undefined;
             }
           }
@@ -89,26 +131,37 @@ function createMemo<T>(fetcher: () => Promise<T>, getScope: () => AbortSignal) {
   };
 }
 
-export function createSessionKeys(deps: SessionKeysDeps = {}): SessionKeys {
-  // Aborted and replaced on every session end (see reset). A derivation in
-  // flight when the session ends holds the signal it started under; once that
-  // signal is aborted its result belongs to a session that no longer exists
-  // and must not be cached into the next one.
+export function createSessionKeys(
+  deps: SessionKeysDeps = {},
+): OwnedSessionKeys {
+  // Aborted on every session end (see reset) and on disposal (see dispose). A
+  // derivation in flight when the session ends holds the signal it started
+  // under; once that signal is aborted its result belongs to a session that no
+  // longer exists and rejects rather than resolving into the next one.
   let sessionScope = new AbortController();
-  const getScope = () => sessionScope.signal;
+  let disposed = false;
+  const getSignal = () => sessionScope.signal;
+  const isDisposed = () => disposed;
 
   const encryptionPrivateKey = createMemo(
     deps.readEncryptionPrivateKey ?? readEncryptionPrivateKey,
-    getScope,
+    getSignal,
+    isDisposed,
   );
   const encryptionPublicKey = createMemo(
     deps.readEncryptionPublicKey ?? readEncryptionPublicKey,
-    getScope,
+    getSignal,
+    isDisposed,
   );
-  const cashuSeed = createMemo(deps.readCashuSeed ?? getCashuSeed, getScope);
+  const cashuSeed = createMemo(
+    deps.readCashuSeed ?? getCashuSeed,
+    getSignal,
+    isDisposed,
+  );
   const sparkMnemonic = createMemo(
     deps.readSparkMnemonic ?? getSparkMnemonic,
-    getScope,
+    getSignal,
+    isDisposed,
   );
   const cashuLockingXpub = createMemo(
     async () =>
@@ -116,7 +169,8 @@ export function createSessionKeys(deps: SessionKeysDeps = {}): SessionKeys {
         await cashuSeed.get(),
         BASE_CASHU_LOCKING_DERIVATION_PATH,
       ),
-    getScope,
+    getSignal,
+    isDisposed,
   );
   const sparkIdentityPublicKey = createMemo(
     async () =>
@@ -126,29 +180,83 @@ export function createSessionKeys(deps: SessionKeysDeps = {}): SessionKeys {
         await sparkMnemonic.get(),
         'mainnet',
       ),
-    getScope,
+    getSignal,
+    isDisposed,
   );
 
+  const clearMemos = () => {
+    encryptionPrivateKey.clear();
+    encryptionPublicKey.clear();
+    cashuSeed.clear();
+    sparkMnemonic.clear();
+    cashuLockingXpub.clear();
+    sparkIdentityPublicKey.clear();
+  };
+
   return {
-    getEncryption: async () =>
-      getEncryption(
-        await encryptionPrivateKey.get(),
-        await encryptionPublicKey.get(),
-      ),
+    getEncryption: async () => {
+      if (disposed) {
+        throw new DisposedError();
+      }
+      // Fences on the scope the composite began under: each getter fences its
+      // own derivation, but a reset landing between the two would otherwise pair
+      // one session's private key with the next session's public key.
+      const signal = sessionScope.signal;
+      const [privateKey, publicKey] = await Promise.all([
+        encryptionPrivateKey.get(),
+        encryptionPublicKey.get(),
+      ]);
+      if (disposed) {
+        throw new DisposedError();
+      }
+      if (signal.aborted) {
+        throw new SessionEndedError();
+      }
+      // The returned capability is revocable: raw key bytes copied out can't be,
+      // but this callable facade rejects once its session ends or the instance
+      // disposes, so a handle a host caches can't keep encrypting with a dead
+      // session's keys.
+      const encryption = getEncryption(privateKey, publicKey);
+      return new Proxy(encryption, {
+        get(target, property, receiver) {
+          const member = Reflect.get(target, property, receiver);
+          if (typeof member !== 'function') {
+            return member;
+          }
+          // Every Encryption method is async, so reject rather than throw: a
+          // revoked handle rejects its promise instead of throwing synchronously.
+          return (...args: unknown[]) => {
+            if (disposed) {
+              return Promise.reject(new DisposedError());
+            }
+            if (signal.aborted) {
+              return Promise.reject(new SessionEndedError());
+            }
+            return Reflect.apply(member, target, args);
+          };
+        },
+      });
+    },
     getEncryptionPublicKey: encryptionPublicKey.get,
     getCashuSeed: cashuSeed.get,
     getSparkMnemonic: sparkMnemonic.get,
     getCashuLockingXpub: cashuLockingXpub.get,
     getSparkIdentityPublicKey: sparkIdentityPublicKey.get,
+    sessionSignal: () => sessionScope.signal,
     reset: () => {
+      // Disposal is terminal: keep the aborted signal and disposed getters
+      // rather than installing a fresh scope a late onSessionEnded would revive.
+      if (disposed) {
+        return;
+      }
       sessionScope.abort();
       sessionScope = new AbortController();
-      encryptionPrivateKey.clear();
-      encryptionPublicKey.clear();
-      cashuSeed.clear();
-      sparkMnemonic.clear();
-      cashuLockingXpub.clear();
-      sparkIdentityPublicKey.clear();
+      clearMemos();
+    },
+    dispose: () => {
+      disposed = true;
+      sessionScope.abort();
+      clearMemos();
     },
   };
 }

--- a/packages/wallet-sdk/domain/user/user-api.test.ts
+++ b/packages/wallet-sdk/domain/user/user-api.test.ts
@@ -3,6 +3,7 @@ import type { Currency } from '@agicash/money';
 import { core, z } from 'zod/mini';
 import type { AgicashDb } from '../../db/database';
 import type { Encryption } from '../../lib/encryption';
+import { SessionEndedError } from '../../lib/error';
 import {
   type Account,
   type CashuAccount as DomainCashuAccount,
@@ -47,13 +48,16 @@ const account = (id: string, currency: Currency): Account =>
 const fakeAccountRepository = {} as AccountRepository;
 const getAccountRepository = async () => fakeAccountRepository;
 
-const fakeKeys = (): SessionKeys => ({
+const fakeKeys = (
+  signal: AbortSignal = new AbortController().signal,
+): SessionKeys => ({
   getEncryption: async () => ({}) as Encryption,
   getEncryptionPublicKey: async () => 'enc-pub',
   getCashuSeed: async () => new Uint8Array(64),
   getSparkMnemonic: async () => 'mnemonic',
   getCashuLockingXpub: async () => 'xpub',
   getSparkIdentityPublicKey: async () => 'spark-id',
+  sessionSignal: () => signal,
   reset: () => undefined,
 });
 
@@ -93,6 +97,14 @@ const createDbFake = (
   return { from } as unknown as AgicashDb;
 };
 
+// The PostgREST builder upsert drives: awaitable (a real promise), with a
+// chainable no-op abortSignal() (the real builder wires the signal into the
+// underlying fetch).
+const rpcQuery = (result: Promise<{ data: unknown; error: unknown }>) => {
+  const query = Object.assign(result, { abortSignal: () => query });
+  return query;
+};
+
 /** Fake covering the single `upsert_user_with_accounts` RPC provision issues. */
 const createUpsertDbFake = (
   outcomes: Array<{ reject: unknown } | { ok: true }>,
@@ -103,16 +115,17 @@ const createUpsertDbFake = (
     rpc: (_name: string, params: Record<string, unknown>) => {
       const outcome = outcomes[Math.min(calls.length, outcomes.length - 1)];
       calls.push(params);
-      if (outcome && 'reject' in outcome) {
-        return Promise.reject(outcome.reject);
-      }
-      return Promise.resolve({
-        data: {
-          user: dbUserRow(String(params.p_user_id)),
-          accounts: accountRows,
-        },
-        error: null,
-      });
+      return rpcQuery(
+        outcome && 'reject' in outcome
+          ? Promise.reject(outcome.reject)
+          : Promise.resolve({
+              data: {
+                user: dbUserRow(String(params.p_user_id)),
+                accounts: accountRows,
+              },
+              error: null,
+            }),
+      );
     },
   } as unknown as AgicashDb;
   return { db, calls };
@@ -230,10 +243,9 @@ describe('createUserApi', () => {
         rpc: (_name: string, params: Record<string, unknown>) => {
           const row = rows[Math.min(calls.length, rows.length - 1)];
           calls.push(params);
-          return Promise.resolve({
-            data: { user: row, accounts: [] },
-            error: null,
-          });
+          return rpcQuery(
+            Promise.resolve({ data: { user: row, accounts: [] }, error: null }),
+          );
         },
       } as unknown as AgicashDb;
       const api = createUserApi({
@@ -342,6 +354,54 @@ describe('createUserApi', () => {
       });
 
       await expect(api.provision({})).rejects.toThrow();
+    });
+
+    it('rejects with SessionEndedError and issues no upsert when the session ends before the write', async () => {
+      const controller = new AbortController();
+      const { db, calls } = createUpsertDbFake([{ ok: true }]);
+      const keys = fakeKeys(controller.signal);
+      // The session ends while the keys the write depends on are being derived.
+      keys.getSparkIdentityPublicKey = async () => {
+        controller.abort();
+        return 'spark-id';
+      };
+      const api = createUserApi({
+        db,
+        getSession: () => ({ isLoggedIn: true, user: authUser('user-a') }),
+        keys,
+        getAccountRepository,
+      });
+
+      await expect(api.provision({})).rejects.toBeInstanceOf(SessionEndedError);
+      expect(calls).toHaveLength(0);
+    });
+
+    it('rejects with SessionEndedError when the session ends while the upsert result is mapped', async () => {
+      const controller = new AbortController();
+      const keys = fakeKeys(controller.signal);
+      const db = {
+        rpc: (_name: string, params: Record<string, unknown>) => {
+          // The session ends while the committed row is mapped to accounts.
+          controller.abort();
+          return rpcQuery(
+            Promise.resolve({
+              data: {
+                user: dbUserRow(String(params.p_user_id)),
+                accounts: [],
+              },
+              error: null,
+            }),
+          );
+        },
+      } as unknown as AgicashDb;
+      const api = createUserApi({
+        db,
+        getSession: () => ({ isLoggedIn: true, user: authUser('user-a') }),
+        keys,
+        getAccountRepository,
+      });
+
+      await expect(api.provision({})).rejects.toBeInstanceOf(SessionEndedError);
     });
   });
 });

--- a/packages/wallet-sdk/domain/user/user-api.ts
+++ b/packages/wallet-sdk/domain/user/user-api.ts
@@ -1,7 +1,11 @@
 import { withRetry } from '@agicash/utils';
 import { core } from 'zod/mini';
 import type { AgicashDb } from '../../db/database';
-import { NoSessionError } from '../../lib/error';
+import {
+  DisposedError,
+  NoSessionError,
+  SessionEndedError,
+} from '../../lib/error';
 import type { AccountRepository } from '../accounts/account-repository';
 import type { AuthSession, UserApi } from '../sdk';
 import type { SessionKeys } from '../sdk/session-keys';
@@ -58,6 +62,11 @@ const defaultAccounts = [
     : []),
 ] as const;
 
+// A session ending mid-operation is terminal for that operation — retrying
+// would only re-derive keys for a session that no longer owns the work.
+const isSessionLifecycleError = (error: unknown): boolean =>
+  error instanceof SessionEndedError || error instanceof DisposedError;
+
 export function createUserApi(deps: Deps): UserApi {
   const readRepository = new ReadUserRepository(deps.db);
   const updateRepository = new UpdateUserRepository(deps.db);
@@ -98,6 +107,12 @@ export function createUserApi(deps: Deps): UserApi {
         throw new NoSessionError();
       }
       const authUser = session.user;
+      // Bind the operation to the session live at its start: the keys derived
+      // and the user id written below belong to it, so a session end mid-flight
+      // must abort the write rather than persist one user's data under the
+      // next session. Captured with no await after the session read so the two
+      // can't straddle a transition.
+      const signal = deps.keys.sessionSignal();
 
       // The memoized getters re-fetch only on failure, so retrying the batch
       // re-derives only the keys that failed, not the ones already resolved.
@@ -114,33 +129,54 @@ export function createUserApi(deps: Deps): UserApi {
             deps.keys.getSparkIdentityPublicKey(),
             deps.getAccountRepository(),
           ]),
+        retry: (attemptIndex, error) =>
+          !signal.aborted &&
+          !isSessionLifecycleError(error) &&
+          attemptIndex < 3,
       });
+
+      if (signal.aborted) {
+        throw new SessionEndedError();
+      }
 
       const upsertRepository = new UpsertUserRepository(
         deps.db,
         accountRepository,
       );
 
-      return withRetry({
+      const result = await withRetry({
         fn: () =>
-          upsertRepository.upsert({
-            id: authUser.id,
-            email: authUser.email,
-            emailVerified: authUser.email_verified,
-            accounts: [...defaultAccounts],
-            cashuLockingXpub,
-            encryptionPublicKey,
-            sparkIdentityPublicKey,
-            termsAcceptedAt: params.termsAcceptedAt,
-            giftCardMintTermsAcceptedAt: params.giftCardMintTermsAcceptedAt,
-          }),
+          upsertRepository.upsert(
+            {
+              id: authUser.id,
+              email: authUser.email,
+              emailVerified: authUser.email_verified,
+              accounts: [...defaultAccounts],
+              cashuLockingXpub,
+              encryptionPublicKey,
+              sparkIdentityPublicKey,
+              termsAcceptedAt: params.termsAcceptedAt,
+              giftCardMintTermsAcceptedAt: params.giftCardMintTermsAcceptedAt,
+            },
+            { abortSignal: signal },
+          ),
         retry: (attemptIndex, error) => {
           if (error instanceof core.$ZodError) {
+            return false;
+          }
+          if (signal.aborted || isSessionLifecycleError(error)) {
             return false;
           }
           return attemptIndex < 2;
         },
       });
+      // The RPC committed A's row, but its accounts were mapped through
+      // toAccount after; if the session ended meanwhile, don't resolve A's
+      // user/accounts into the next session's caller.
+      if (signal.aborted) {
+        throw new SessionEndedError();
+      }
+      return result;
     },
   };
 }

--- a/packages/wallet-sdk/index.ts
+++ b/packages/wallet-sdk/index.ts
@@ -16,9 +16,6 @@ export {
   DomainError,
   NotFoundError,
   SdkError,
-  // Never retry: the operation's session ended (sign-out / different-user
-  // login / expiry), so a retry would run under a session that no longer owns
-  // it. A fresh operation under the new session is what recovers.
   SessionEndedError,
   UniqueConstraintError,
 } from './lib/error';

--- a/packages/wallet-sdk/index.ts
+++ b/packages/wallet-sdk/index.ts
@@ -16,6 +16,10 @@ export {
   DomainError,
   NotFoundError,
   SdkError,
+  // Never retry: the operation's session ended (sign-out / different-user
+  // login / expiry), so a retry would run under a session that no longer owns
+  // it. A fresh operation under the new session is what recovers.
+  SessionEndedError,
   UniqueConstraintError,
 } from './lib/error';
 export { WebAssemblyUnavailableError } from './lib/spark/errors';

--- a/packages/wallet-sdk/lib/encryption.ts
+++ b/packages/wallet-sdk/lib/encryption.ts
@@ -188,23 +188,6 @@ export type Encryption = {
   ) => Promise<T>;
 };
 
-export const getEncryption = (
-  privateKey: Uint8Array,
-  publicKeyHex: string,
-): Encryption => {
-  return {
-    encrypt: async <T = unknown>(data: T) =>
-      encryptToPublicKey(data, publicKeyHex),
-    decrypt: async <T = unknown>(data: string) =>
-      decryptWithPrivateKey<T>(data, privateKey),
-    encryptBatch: async <T extends readonly unknown[]>(data: T) =>
-      encryptBatchToPublicKey(data, publicKeyHex),
-    decryptBatch: async <T extends readonly unknown[]>(
-      data: readonly [...{ [K in keyof T]: string }],
-    ) => decryptBatchWithPrivateKey<T>(data, privateKey),
-  };
-};
-
 // 10111099 is 'enc' (for encryption) in ascii
 const encryptionKeyDerivationPath = `m/10111099'/0'`;
 

--- a/packages/wallet-sdk/lib/error.ts
+++ b/packages/wallet-sdk/lib/error.ts
@@ -50,8 +50,9 @@ export class DisposedError extends SdkError {
 /**
  * Thrown when the session an operation belongs to ends (sign-out, a different
  * user's login, or expiry) while the operation is in flight, so its result must
- * not be used. Transient, unlike {@link DisposedError}: the instance stays
- * usable and a fresh operation under the new session succeeds.
+ * not be used. Never retry the same operation — it would run under a session
+ * that no longer owns it. Transient, unlike {@link DisposedError}: the instance
+ * stays usable, and a fresh operation under the new session is what recovers.
  */
 export class SessionEndedError extends SdkError {
   constructor() {

--- a/packages/wallet-sdk/lib/error.ts
+++ b/packages/wallet-sdk/lib/error.ts
@@ -47,6 +47,19 @@ export class DisposedError extends SdkError {
   }
 }
 
+/**
+ * Thrown when the session an operation belongs to ends (sign-out, a different
+ * user's login, or expiry) while the operation is in flight, so its result must
+ * not be used. Transient, unlike {@link DisposedError}: the instance stays
+ * usable and a fresh operation under the new session succeeds.
+ */
+export class SessionEndedError extends SdkError {
+  constructor() {
+    super('The session ended before the operation completed');
+    this.name = 'SessionEndedError';
+  }
+}
+
 /** Thrown when a namespace is accessed before its migration slice has landed. */
 export class NotImplementedError extends SdkError {
   constructor(namespace: string) {

--- a/packages/wallet-sdk/temporary.ts
+++ b/packages/wallet-sdk/temporary.ts
@@ -36,12 +36,15 @@ export type {
   TransactionDetailsParserShape,
 } from './domain/transactions/transaction-details/transaction-details-types';
 export type { RepositoryCreateQuoteParams } from './domain/receive/spark-receive-quote-core';
+// TEMPORARY (the four ECIES primitives only — encryptToPublicKey,
+// encryptBatchToPublicKey, decryptWithPrivateKey, decryptBatchWithPrivateKey):
+// they back the web's encryption-hooks duplicate of the SDK session-key facade
+// and are deleted at step 18 with it. readEncryption{Private,Public}Key stay.
 export {
   decryptBatchWithPrivateKey,
   decryptWithPrivateKey,
   encryptBatchToPublicKey,
   encryptToPublicKey,
-  getEncryption,
   readEncryptionPrivateKey,
   readEncryptionPublicKey,
 } from './lib/encryption';

--- a/packages/wallet-sdk/temporary.ts
+++ b/packages/wallet-sdk/temporary.ts
@@ -36,10 +36,6 @@ export type {
   TransactionDetailsParserShape,
 } from './domain/transactions/transaction-details/transaction-details-types';
 export type { RepositoryCreateQuoteParams } from './domain/receive/spark-receive-quote-core';
-// TEMPORARY (the four ECIES primitives only — encryptToPublicKey,
-// encryptBatchToPublicKey, decryptWithPrivateKey, decryptBatchWithPrivateKey):
-// they back the web's encryption-hooks duplicate of the SDK session-key facade
-// and are deleted at step 18 with it. readEncryption{Private,Public}Key stay.
 export {
   decryptBatchWithPrivateKey,
   decryptWithPrivateKey,


### PR DESCRIPTION
Stacked on #1167. This is the session-lifecycle hardening referenced in the provision-internalization design doc (D5's substrate) — the follow-up triage promised on the last review round.

## What it fixes

Internal adversarial review of the session surface found lifecycle gaps where an in-flight or retained handle could outlive its session:

1. **Consumer fence** — a derivation in flight when the session ends now rejects with a typed `SessionEndedError` instead of resolving the old user's value to its caller: after every derivation await, on the cached-branch under a mid-`reset()` abort (synchronous listener reentrancy), and through the composite `getEncryption` (epoch-bound, so a cross-session private/public pair is impossible). `provision` and the accounts operations bind to the session signal at start and re-check after their DB round-trips; the abort signal threads through repository reads/writes.
2. **Revocable encryption capability** — `getEncryption()` returns a session-guarded facade; a handle retained across sign-out/dispose rejects instead of silently encrypting with the previous user's keys. Web side: a login transition without a prior sign-out now evicts the derived-key queries so the next read derives fresh (sign-out already cleared everything).
3. **Terminal dispose** — `dispose()` is now terminal, distinct from reusable session `reset()`: retained key getters and namespace handles reject (`DisposedError`), pending work aborts, `reset()` after dispose is a no-op.

## Contract deltas (called out for review)

- `SessionEndedError` is a new typed rejection, exported from the package root with never-retry guidance.
- `dispose()` now rejects new calls on handles retained from before it — extends the documented "pending namespace promises reject on dispose" guarantee to retained-handle calls.
- Public `auth.getSession()` after dispose is deliberately unchanged (a last-snapshot read; documented).

## Evidence

- Every fence test was proven **red on the base commit** (the old code resolves stale values — the suite previously blessed that behavior) and green with the fence; an independent reviewer re-established red-on-base from scratch before this PR was cut.
- Full chain on the branch tip: typecheck clean across the monorepo, wallet-sdk 112/112, web 37/37, lint clean.

## Known residuals (documented, not fixed here)

- The `os.signIn(B)`-before-cleanup ordering window (cross-user; reproduced in review). Not fixable at the session-keys layer — it needs the auth-transition suspension, which is exactly **D5 of the provision-internalization design doc**; it lands with that round, gated by a real Open Secret integration test.
- Remote-write cancellation is best-effort (a server commit can win the race); the guarantee is no cross-user result or use, and the wording in code now says exactly that.

## Asks

- The web `refreshSession` → key-query eviction wiring has a unit-tested core but the hook wiring itself wants a smoke in your environment (cross-user login without sign-out → encryption works for the new user).

Draft until our final internal review pass clears (running now); lifting after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)