### PR TITLE
Internalize provisioning + session.established event

### DIFF
--- a/apps/web-wallet/app/entry.client.tsx
+++ b/apps/web-wallet/app/entry.client.tsx
@@ -21,6 +21,7 @@ import { loadFeatureFlags } from './features/shared/feature-flags';
 // later slice constructs the SDK explicitly at boot and moves feature flags
 // onto the instance, dropping this ordering dependency (PR #1166).
 import './features/shared/sdk.client';
+import { registerSessionStarted } from './features/user/session-started';
 import { registerMoneyDevToolsFormatter } from './lib/money-devtools-formatter';
 import { getTracesSampleRate, sanitizeUrl } from './tracing-utils';
 
@@ -47,6 +48,11 @@ ensureBreezWasm().catch(() => {
 // for user-targeted flags after login.
 configureFeatureFlags(agicashDbClient);
 void loadFeatureFlags();
+
+// Seed the user + accounts caches from the SDK's auth.session-started event once
+// provisioning settles the identity. Registered before the router so the first
+// protected middleware reads already-seeded caches.
+registerSessionStarted();
 
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN ?? '';
 if (!sentryDsn) {

--- a/apps/web-wallet/app/features/user/auth.ts
+++ b/apps/web-wallet/app/features/user/auth.ts
@@ -65,9 +65,16 @@ export const authQueryOptions = () =>
       try {
         await sdk.init();
       } catch (error) {
-        // Restore failed with tokens present (e.g. a network blip at boot).
-        // Boot anonymous; init()'s rejection is not memoized, so a later
-        // invalidateAuthQueries() retries the restore.
+        // A session that established but whose provisioning threw is not an
+        // anonymous boot: the identity is authenticated, only provisioning as
+        // the settled user failed. Surface it to the error boundary rather than
+        // masking a half-provisioned session as logged-out. init()'s rejection
+        // is not memoized, so a later invalidateAuthQueries() retries.
+        if (sdk.auth.getSession().isLoggedIn) {
+          throw error;
+        }
+        // Restore genuinely failed with tokens present (e.g. a network blip at
+        // boot). Boot anonymous; the same un-memoized retry applies.
         console.error('Failed to initialize sdk', { cause: error });
         Sentry.setUser(null);
         sessionHintCookie.clear();

--- a/apps/web-wallet/app/features/user/session-started.ts
+++ b/apps/web-wallet/app/features/user/session-started.ts
@@ -1,0 +1,20 @@
+import { AccountsCache } from '~/features/accounts/account-hooks';
+import { getQueryClient } from '~/features/shared/query-client';
+import { sdk } from '~/features/shared/sdk.client';
+import { UserCache } from '~/features/user/user-hooks';
+
+/**
+ * Seeds the user and accounts caches from the SDK's `auth.session-started` event
+ * so the provisioned identity and its accounts are in cache before the
+ * protected tree reads them — the host no longer provisions or fetches them
+ * itself. Registered at boot, before the router, so the first protected
+ * middleware sees the seeded caches; replay-latest delivers the most recent
+ * payload even when `init()` established the session before this subscribed.
+ * @returns The unsubscribe function.
+ */
+export const registerSessionStarted = (): (() => void) =>
+  sdk.events.on('auth.session-started', ({ user, accounts }) => {
+    const queryClient = getQueryClient();
+    queryClient.setQueryData([UserCache.Key], user);
+    queryClient.setQueryData([AccountsCache.Key], accounts);
+  });

--- a/apps/web-wallet/app/features/user/user-hooks.tsx
+++ b/apps/web-wallet/app/features/user/user-hooks.tsx
@@ -209,8 +209,17 @@ export const useUpdateUsername = () => {
 
 export const useAcceptTerms = () => {
   const { mutateAsync } = useUserUpdatingMutation(
-    (params: { walletTerms?: boolean; giftCardTerms?: boolean }) =>
-      sdk.user.acceptTerms(params),
+    (params: { walletTerms?: boolean; giftCardTerms?: boolean }) => {
+      // The acceptance timestamp is the moment of this click, recorded here
+      // rather than server-side, so it reflects when the user actually accepted.
+      const acceptedAt = new Date().toISOString();
+      return sdk.user.acceptTerms({
+        walletTermsAcceptedAt: params.walletTerms ? acceptedAt : undefined,
+        giftCardMintTermsAcceptedAt: params.giftCardTerms
+          ? acceptedAt
+          : undefined,
+      });
+    },
   );
 
   return mutateAsync;

--- a/apps/web-wallet/app/routes/_protected.tsx
+++ b/apps/web-wallet/app/routes/_protected.tsx
@@ -1,9 +1,7 @@
-import type { AuthUser, User } from '@agicash/wallet-sdk';
+import type { AuthUser } from '@agicash/wallet-sdk';
 import { shouldAcceptTerms } from '@agicash/wallet-sdk';
 import { ensureBreezWasm } from '@agicash/wallet-sdk/temporary';
-import type { QueryClient } from '@tanstack/react-query';
 import { Outlet, redirect } from 'react-router';
-import { AccountsCache } from '~/features/accounts/account-hooks';
 import { supabaseSessionTokenQuery } from '~/features/agicash-db/supabase-session';
 import { LoadingScreen } from '~/features/loading/LoadingScreen';
 import { seedQueryOptions } from '~/features/shared/cashu-query-options';
@@ -37,51 +35,6 @@ const buildRedirectWithReturnUrl = (
   }
   const search = `?${searchParams.toString()}`;
   return redirect(`${destinationRoute}${search}${hash}`);
-};
-
-const hasUserChanged = (user: User, authUser: AuthUser) => {
-  const currentAuthUserEmail = authUser.email ?? null;
-  const currentUserEmail = user.isGuest ? null : user.email;
-
-  return (
-    currentUserEmail !== currentAuthUserEmail ||
-    user.emailVerified !== authUser.email_verified
-  );
-};
-
-const ensureUserData = async (
-  queryClient: QueryClient,
-  authUser: AuthUser,
-  termsAcceptedAt?: string,
-  giftCardMintTermsAcceptedAt?: string,
-): Promise<User> => {
-  let user = getUserFromCache(queryClient);
-
-  if (!user) {
-    queryClient.prefetchQuery(supabaseSessionTokenQuery());
-  }
-
-  if (!user || hasUserChanged(user, authUser)) {
-    // TEMPORARY: these prefetches populate cache entries that receive/send/claim
-    // repositories not yet migrated into the SDK still read (encryption, seed,
-    // spark mnemonic). Each prefetched entry exists only for its unmigrated
-    // feature and is deleted when that feature migrates into the SDK — all gone
-    // by step 18.
-    const [{ user: upsertedUser, accounts }] = await Promise.all([
-      sdk.user.provision({
-        termsAcceptedAt,
-        giftCardMintTermsAcceptedAt,
-      }),
-      queryClient.ensureQueryData(encryptionQueryOptions()),
-      queryClient.ensureQueryData(sparkMnemonicQueryOptions()),
-      queryClient.ensureQueryData(seedQueryOptions()),
-    ]);
-    user = upsertedUser;
-    queryClient.setQueryData([UserCache.Key], user);
-    queryClient.setQueryData([AccountsCache.Key], accounts);
-  }
-
-  return user;
 };
 
 const routeGuardMiddleware: Route.ClientMiddlewareFunction = async (
@@ -125,6 +78,23 @@ const routeGuardMiddleware: Route.ClientMiddlewareFunction = async (
     throw redirect(`/home${search}${hash}`);
   }
 
+  // TEMPORARY: these prefetches populate cache entries that receive/send/claim
+  // repositories not yet migrated into the SDK still read (session token,
+  // encryption, seed, spark mnemonic); each is deleted when its feature migrates
+  // into the SDK. ensureBreezWasm first: the spark mnemonic prefetch derives the
+  // Spark identity via defaultExternalSigner(), which requires WASM. Shared with
+  // entry.client.tsx so the init is typically already in-flight here.
+  await ensureBreezWasm();
+  queryClient.prefetchQuery(supabaseSessionTokenQuery());
+  await Promise.all([
+    queryClient.ensureQueryData(encryptionQueryOptions()),
+    queryClient.ensureQueryData(sparkMnemonicQueryOptions()),
+    queryClient.ensureQueryData(seedQueryOptions()),
+  ]);
+
+  // The provisioned user and accounts arrive via the SDK's auth.session-started
+  // event (seeded into cache at boot). Replay any terms accepted before this
+  // session existed, then gate on the result.
   const pendingTermsAcceptedAt = pendingWalletTermsStorage.get();
   if (pendingTermsAcceptedAt) {
     pendingWalletTermsStorage.remove();
@@ -136,16 +106,14 @@ const routeGuardMiddleware: Route.ClientMiddlewareFunction = async (
     pendingGiftCardMintTermsStorage.remove();
   }
 
-  // ensureUserData derives the Spark identity public key via defaultExternalSigner(),
-  // which requires WASM to be initialized. Shared with entry.client.tsx so the init
-  // is typically already in-flight (or complete) by the time we await here.
-  await ensureBreezWasm();
-  const user = await ensureUserData(
-    queryClient,
-    authUser,
-    pendingTermsAcceptedAt,
-    pendingGiftCardMintTermsAcceptedAt,
-  );
+  let user = getUserFromCache(queryClient) ?? (await sdk.user.get());
+  if (pendingTermsAcceptedAt || pendingGiftCardMintTermsAcceptedAt) {
+    user = await sdk.user.acceptTerms({
+      walletTermsAcceptedAt: pendingTermsAcceptedAt,
+      giftCardMintTermsAcceptedAt: pendingGiftCardMintTermsAcceptedAt,
+    });
+    queryClient.setQueryData([UserCache.Key], user);
+  }
 
   const shouldRedirectToAcceptTerms =
     shouldAcceptTerms(user) && !isAcceptTermsRoute;

--- a/packages/wallet-sdk/domain/accounts/accounts-api.test.ts
+++ b/packages/wallet-sdk/domain/accounts/accounts-api.test.ts
@@ -180,7 +180,7 @@ describe('createAccountsApi', () => {
       const balances = accounts.map((account) =>
         getAccountBalance(account)?.amount('sat').toNumber(),
       );
-      expect(balances).toEqual([150, 42]);
+      expect(balances).toEqual(expect.arrayContaining([150, 42]));
     });
 
     it('throws NoSessionError without a session', async () => {

--- a/packages/wallet-sdk/domain/sdk/events.test.ts
+++ b/packages/wallet-sdk/domain/sdk/events.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { nullLogger } from '../../lib/logger';
+import type { Account } from '../accounts/account';
+import type { User } from '../user/user';
 import { WalletEventEmitter } from './events';
 
 describe('WalletEventEmitter', () => {
@@ -69,5 +71,69 @@ describe('WalletEventEmitter', () => {
 
     expect(secondHandlerRan).toBe(true);
     expect(errors).toHaveLength(1);
+  });
+
+  describe('auth.session-started replay-latest', () => {
+    const startedPayload = (id: string) => ({
+      user: { id } as unknown as User,
+      accounts: [] as unknown as Account[],
+    });
+
+    it('replays the most recent payload to a handler subscribed after the emit', () => {
+      const emitter = new WalletEventEmitter(nullLogger);
+      const payload = startedPayload('user-1');
+      emitter.emit('auth.session-started', payload);
+
+      const received: unknown[] = [];
+      emitter.on('auth.session-started', (p) => received.push(p));
+
+      expect(received).toEqual([payload]);
+    });
+
+    it('replays only the latest payload', () => {
+      const emitter = new WalletEventEmitter(nullLogger);
+      emitter.emit('auth.session-started', startedPayload('user-1'));
+      const latest = startedPayload('user-2');
+      emitter.emit('auth.session-started', latest);
+
+      const received: unknown[] = [];
+      emitter.on('auth.session-started', (p) => received.push(p));
+
+      expect(received).toEqual([latest]);
+    });
+
+    it('delivers a live emit to an already-subscribed handler', () => {
+      const emitter = new WalletEventEmitter(nullLogger);
+      const received: unknown[] = [];
+      emitter.on('auth.session-started', (p) => received.push(p));
+
+      const payload = startedPayload('user-1');
+      emitter.emit('auth.session-started', payload);
+
+      expect(received).toEqual([payload]);
+    });
+
+    it('does not replay other event types to a late subscriber', () => {
+      const emitter = new WalletEventEmitter(nullLogger);
+      emitter.emit('auth.session-expired', {});
+
+      let calls = 0;
+      emitter.on('auth.session-expired', () => {
+        calls += 1;
+      });
+
+      expect(calls).toBe(0);
+    });
+
+    it('does not replay after the retained payload is cleared', () => {
+      const emitter = new WalletEventEmitter(nullLogger);
+      emitter.emit('auth.session-started', startedPayload('user-1'));
+      emitter.clear();
+
+      const received: unknown[] = [];
+      emitter.on('auth.session-started', (p) => received.push(p));
+
+      expect(received).toEqual([]);
+    });
   });
 });

--- a/packages/wallet-sdk/domain/sdk/events.ts
+++ b/packages/wallet-sdk/domain/sdk/events.ts
@@ -29,6 +29,15 @@ export type WalletEventMap = {
    * session-derived state from it.
    */
   'auth.session-refreshed': Record<string, never>;
+  /**
+   * A session settled onto its current user (initial login/restore or a
+   * mid-session identity change) and the user was provisioned — carries the
+   * provisioned user and their accounts so the host seeds its caches by plain
+   * reads. Replay-latest: a handler that subscribes after the establish still
+   * receives the most recent payload immediately (the common React case, where
+   * the tree mounts after `init()` already established the session).
+   */
+  'auth.session-started': { user: User; accounts: Account[] };
   'user.updated': { user: User };
   'account.created': { account: Account };
   /** A persisted row changed; the payload carries a `version` consumers gate on. */
@@ -85,6 +94,11 @@ type Handler = (payload: never) => void;
 
 export class WalletEventEmitter implements WalletEvents {
   private readonly handlers = new Map<keyof WalletEventMap, Set<Handler>>();
+  // Retained for replay-latest: the most recent auth.session-started payload,
+  // replayed to a handler that subscribes after the establish.
+  private lastSessionStarted:
+    | WalletEventMap['auth.session-started']
+    | undefined;
 
   constructor(private readonly logger: Logger) {}
 
@@ -95,15 +109,38 @@ export class WalletEventEmitter implements WalletEvents {
     const set = this.handlers.get(event) ?? new Set<Handler>();
     set.add(handler as Handler);
     this.handlers.set(event, set);
+    if (event === 'auth.session-started' && this.lastSessionStarted) {
+      this.dispatch(
+        handler as (payload: WalletEventMap['auth.session-started']) => void,
+        'auth.session-started',
+        this.lastSessionStarted,
+      );
+    }
     return () => {
       set.delete(handler as Handler);
     };
+  }
+
+  private dispatch<K extends keyof WalletEventMap>(
+    handler: (payload: WalletEventMap[K]) => void,
+    event: K,
+    payload: WalletEventMap[K],
+  ): void {
+    try {
+      handler(payload);
+    } catch (error) {
+      this.logger.error(`Event handler for ${event} threw`, error);
+    }
   }
 
   emit<K extends keyof WalletEventMap>(
     event: K,
     payload: WalletEventMap[K],
   ): void {
+    if (event === 'auth.session-started') {
+      this.lastSessionStarted =
+        payload as WalletEventMap['auth.session-started'];
+    }
     const set = this.handlers.get(event);
     if (!set) {
       return;
@@ -111,11 +148,21 @@ export class WalletEventEmitter implements WalletEvents {
     // Snapshot: a handler that (un)subscribes mid-emit must not change the
     // current dispatch.
     for (const handler of [...set]) {
-      try {
-        (handler as (payload: WalletEventMap[K]) => void)(payload);
-      } catch (error) {
-        this.logger.error(`Event handler for ${event} threw`, error);
-      }
+      this.dispatch(
+        handler as (payload: WalletEventMap[K]) => void,
+        event,
+        payload,
+      );
     }
+  }
+
+  /**
+   * Drops all retained replay-latest payloads so a subscriber that registers
+   * after a session end is not replayed the previous session's events (today the
+   * retained `auth.session-started` user and accounts; extend here as more events
+   * adopt replay-latest). Called by the SDK on session end.
+   */
+  clear(): void {
+    this.lastSessionStarted = undefined;
   }
 }

--- a/packages/wallet-sdk/domain/sdk/sdk.ts
+++ b/packages/wallet-sdk/domain/sdk/sdk.ts
@@ -29,6 +29,7 @@ import { AuthService } from '../user/auth-service';
 import { createUserApi } from '../user/user-api';
 import { WalletEventEmitter } from './events';
 import { type OwnedSessionKeys, createSessionKeys } from './session-keys';
+import { createUserProvisioner } from './user-provisioner';
 
 // The current instance: the instance currently constructed and not yet
 // disposed. Makes the one-instance-per-process constraint (see the constructor
@@ -96,6 +97,17 @@ export class AgicashSdk implements Sdk {
       generateToken: () => openSecret.generateThirdPartyToken(),
     });
 
+    // Provisioning runs internally, post-establish, as the settled identity —
+    // fingerprint-guarded so it re-provisions only when the identity changes,
+    // held in memory, not persisted. A terminal failure propagates to the caller
+    // so the host surfaces its error boundary; a session-lifecycle abort is moot
+    // for the session that is starting. The guard resets on session end (below)
+    // so a same-user re-login re-provisions the caches the end cleared.
+    const userProvisioner = createUserProvisioner({
+      provision: () => this.user.provision(),
+      emit: (payload) => events.emit('auth.session-started', payload),
+    });
+
     this.authService = new AuthService({
       os: openSecret,
       storage: config.auth.storage,
@@ -103,6 +115,7 @@ export class AgicashSdk implements Sdk {
         (await config.auth.generateGuestPassword?.()) ??
         generateRandomPassword(32),
       events,
+      onSessionStarted: userProvisioner.provision,
       onSessionEnded: () => {
         // The token cache must die with the session: a token minted for one
         // user must never serve the next login's queries. Anything wiped here
@@ -113,6 +126,11 @@ export class AgicashSdk implements Sdk {
         clearSparkWallets();
         clearAgicashMintAuthToken();
         keys.reset();
+        // Provisioning state is session-scoped too: after a sign-out the next
+        // login — even the same user — must re-provision and re-emit
+        // auth.session-started so the host reseeds the caches it cleared on end.
+        userProvisioner.reset();
+        events.clear();
       },
       logger: config.logger,
     });

--- a/packages/wallet-sdk/domain/sdk/user-provisioner.test.ts
+++ b/packages/wallet-sdk/domain/sdk/user-provisioner.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+import type { AuthUser } from '.';
+import { DisposedError, SessionEndedError } from '../../lib/error';
+import type { Account } from '../accounts/account';
+import type { User } from '../user/user';
+import { createUserProvisioner } from './user-provisioner';
+
+const authUser = (id: string): AuthUser =>
+  ({
+    id,
+    email: 'a@b.c',
+    email_verified: true,
+  }) as AuthUser;
+
+const makeHarness = (
+  provision?: () => Promise<{ user: User; accounts: Account[] }>,
+) => {
+  let provisionCalls = 0;
+  const emitted: { user: User; accounts: Account[] }[] = [];
+  const provisioner = createUserProvisioner({
+    provision:
+      provision ??
+      (async () => {
+        provisionCalls += 1;
+        return { user: { id: 'user-1' } as unknown as User, accounts: [] };
+      }),
+    emit: (payload) => {
+      emitted.push(payload);
+    },
+  });
+  return { provisioner, emitted, provisionCalls: () => provisionCalls };
+};
+
+describe('createUserProvisioner', () => {
+  it('provisions and emits on the first establish', async () => {
+    const { provisioner, emitted, provisionCalls } = makeHarness();
+    await provisioner.provision(authUser('user-1'));
+    expect(emitted).toHaveLength(1);
+    expect(provisionCalls()).toBe(1);
+  });
+
+  it('skips a same-user re-establish (fingerprint guard) without a session end', async () => {
+    const { provisioner, emitted, provisionCalls } = makeHarness();
+    await provisioner.provision(authUser('user-1'));
+    await provisioner.provision(authUser('user-1'));
+    expect(emitted).toHaveLength(1);
+    expect(provisionCalls()).toBe(1);
+  });
+
+  it('re-provisions and re-emits on a same-user re-establish after reset', async () => {
+    const { provisioner, emitted, provisionCalls } = makeHarness();
+    await provisioner.provision(authUser('user-1'));
+    provisioner.reset();
+    await provisioner.provision(authUser('user-1'));
+    expect(emitted).toHaveLength(2);
+    expect(provisionCalls()).toBe(2);
+  });
+
+  it('re-provisions when the identity changes', async () => {
+    const { provisioner, emitted } = makeHarness();
+    await provisioner.provision(authUser('user-1'));
+    await provisioner.provision(authUser('user-2'));
+    expect(emitted).toHaveLength(2);
+  });
+
+  it('propagates a terminal provision failure', async () => {
+    const { provisioner } = makeHarness(async () => {
+      throw new Error('provision failed');
+    });
+    await expect(provisioner.provision(authUser('user-1'))).rejects.toThrow(
+      'provision failed',
+    );
+  });
+
+  it('swallows a session-lifecycle abort without emitting', async () => {
+    const { provisioner, emitted } = makeHarness(async () => {
+      throw new SessionEndedError();
+    });
+    await provisioner.provision(authUser('user-1'));
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('swallows a DisposedError without emitting', async () => {
+    const { provisioner, emitted } = makeHarness(async () => {
+      throw new DisposedError();
+    });
+    await provisioner.provision(authUser('user-1'));
+    expect(emitted).toHaveLength(0);
+  });
+});

--- a/packages/wallet-sdk/domain/sdk/user-provisioner.ts
+++ b/packages/wallet-sdk/domain/sdk/user-provisioner.ts
@@ -1,0 +1,53 @@
+import type { AuthUser } from '.';
+import { DisposedError, SessionEndedError } from '../../lib/error';
+import type { Account } from '../accounts/account';
+import type { User } from '../user/user';
+
+type UserProvisionerDeps = {
+  /** Provisions the settled identity; returns the user and their accounts. */
+  provision: () => Promise<{ user: User; accounts: Account[] }>;
+  /** Emits the `auth.session-started` payload to the host. */
+  emit: (payload: { user: User; accounts: Account[] }) => void;
+};
+
+/**
+ * Provisions the settled user once per identity and emits `auth.session-started`.
+ * Fingerprint-guarded in memory (userId + email + emailVerified) so it fires only
+ * when the identity changes; a terminal provision failure propagates to the caller
+ * (so the host surfaces its error boundary), while a session-lifecycle abort is
+ * swallowed (moot for a session that is ending or gone). `reset` clears the guard
+ * on session end so a same-user re-login after a sign-out — which cleared the host
+ * caches — re-provisions and re-emits rather than being skipped as unchanged.
+ */
+export const createUserProvisioner = (
+  deps: UserProvisionerDeps,
+): {
+  provision: (authUser: AuthUser) => Promise<void>;
+  reset: () => void;
+} => {
+  let lastProvisionedFingerprint: string | undefined;
+  return {
+    provision: async (authUser: AuthUser): Promise<void> => {
+      const fingerprint = `${authUser.id} ${authUser.email ?? ''} ${authUser.email_verified}`;
+      if (fingerprint === lastProvisionedFingerprint) {
+        return;
+      }
+      try {
+        const { user, accounts } = await deps.provision();
+        lastProvisionedFingerprint = fingerprint;
+        deps.emit({ user, accounts });
+      } catch (error) {
+        if (
+          error instanceof SessionEndedError ||
+          error instanceof DisposedError
+        ) {
+          return;
+        }
+        throw error;
+      }
+    },
+    reset: (): void => {
+      lastProvisionedFingerprint = undefined;
+    },
+  };
+};

--- a/packages/wallet-sdk/domain/sdk/user.ts
+++ b/packages/wallet-sdk/domain/sdk/user.ts
@@ -9,34 +9,30 @@ export type UserApi = {
   setDefaultAccount(params: SetDefaultAccountParams): Promise<User>;
   setDefaultCurrency(params: SetDefaultCurrencyParams): Promise<User>;
   /**
-   * Provisions the signed-in user. Idempotent — creates the user row and
-   * default accounts on first sign-in, applies updates when the auth data or
-   * terms params changed, and no-ops otherwise. Returns the user with their
-   * accounts for the host to seed its caches.
+   * Provisions the signed-in user. Fired internally on the auth lifecycle
+   * (post-establish), not host-called. Idempotent — creates the user row and
+   * default accounts on the first establish of an identity, updates the auth
+   * data (email / email-verified) when it changed, and no-ops otherwise.
+   * Returns the user with their accounts (carried to the host via the
+   * `auth.session-started` event). Terms are recorded separately via
+   * `acceptTerms`.
    */
-  provision(
-    params: ProvisionUserParams,
-  ): Promise<{ user: User; accounts: Account[] }>;
-};
-
-export type ProvisionUserParams = {
-  /**
-   * ISO 8601 timestamp replayed from the host's pending-terms storage — the
-   * time the user accepted wallet terms before the user row existed, not
-   * "now". `acceptTerms` is the in-session boolean that stamps the time
-   * itself.
-   */
-  termsAcceptedAt?: string;
-  /**
-   * ISO 8601 timestamp replayed from the host's pending-terms storage — the
-   * time the user accepted gift-card-mint terms before the user row existed.
-   */
-  giftCardMintTermsAcceptedAt?: string;
+  provision(): Promise<{ user: User; accounts: Account[] }>;
 };
 
 export type AcceptTermsParams = {
-  walletTerms?: boolean;
-  giftCardTerms?: boolean;
+  /**
+   * ISO 8601 timestamp when the user accepted wallet terms — the real click
+   * time the host captured (pre-auth pending acceptance replayed post-provision,
+   * or an in-session accept), not "now" stamped at the SDK. Omit to leave wallet
+   * terms unchanged.
+   */
+  walletTermsAcceptedAt?: string;
+  /**
+   * ISO 8601 timestamp when the user accepted gift-card-mint terms. Omit to
+   * leave gift-card-mint terms unchanged.
+   */
+  giftCardMintTermsAcceptedAt?: string;
 };
 
 export type SetDefaultAccountParams = {

--- a/packages/wallet-sdk/domain/user/auth-service.test.ts
+++ b/packages/wallet-sdk/domain/user/auth-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { DisposedError } from '../../lib/error';
 import { nullLogger } from '../../lib/logger';
-import type { AuthKeyValueStore, AuthStorage } from '../sdk';
+import type { AuthKeyValueStore, AuthStorage, AuthUser } from '../sdk';
 import { WalletEventEmitter } from '../sdk/events';
 import { AuthService, type OpenSecretAuthApi } from './auth-service';
 
@@ -100,6 +100,7 @@ const createService = (
     os?: Partial<OpenSecretAuthApi>;
     storage?: ReturnType<typeof createStorage>;
     onSessionEnded?: () => void;
+    onSessionStarted?: (authUser: AuthUser) => Promise<void>;
   } = {},
 ) => {
   const storage = options.storage ?? createStorage();
@@ -111,6 +112,7 @@ const createService = (
     generateGuestPassword: async () => 'generated-pw',
     events,
     onSessionEnded: options.onSessionEnded,
+    onSessionStarted: options.onSessionStarted,
     logger: nullLogger,
   });
   return { service, storage, calls, events };
@@ -120,6 +122,113 @@ describe('AuthService', () => {
   it('starts anonymous', () => {
     const { service } = createService();
     expect(service.getSession()).toEqual({ isLoggedIn: false });
+  });
+
+  describe('onSessionStarted (provisioning)', () => {
+    const withTokens = (storage: ReturnType<typeof createStorage>) => {
+      storage.persistent.data.set('access_token', createJwt(600));
+      storage.persistent.data.set('refresh_token', createJwt(3600));
+    };
+
+    it('fires post-establish on restore, with the settled user', async () => {
+      const storage = createStorage();
+      withTokens(storage);
+      const established: AuthUser[] = [];
+      const { service } = createService({
+        storage,
+        onSessionStarted: async (user) => {
+          established.push(user);
+        },
+      });
+
+      await service.restoreSession();
+
+      expect(established).toHaveLength(1);
+      expect(established[0]?.id).toBe('user-1');
+      expect(service.getSession().isLoggedIn).toBe(true);
+    });
+
+    it('fires post-establish on a sign-in', async () => {
+      const established: AuthUser[] = [];
+      const { service } = createService({
+        onSessionStarted: async (user) => {
+          established.push(user);
+        },
+      });
+
+      await service.signIn('a@b.c', 'pw');
+
+      expect(established).toHaveLength(1);
+      expect(established[0]?.id).toBe('user-1');
+    });
+
+    it('propagates a terminal provisioning failure out of the verb, keeping the established session', async () => {
+      const { service } = createService({
+        onSessionStarted: async () => {
+          throw new Error('provision failed');
+        },
+      });
+
+      await expect(service.signIn('a@b.c', 'pw')).rejects.toThrow(
+        'provision failed',
+      );
+      // The identity is authenticated; only provisioning failed.
+      expect(service.getSession().isLoggedIn).toBe(true);
+    });
+
+    it('propagates a terminal provisioning failure out of restore', async () => {
+      const storage = createStorage();
+      withTokens(storage);
+      const { service } = createService({
+        storage,
+        onSessionStarted: async () => {
+          throw new Error('provision failed');
+        },
+      });
+
+      await expect(service.restoreSession()).rejects.toThrow(
+        'provision failed',
+      );
+      expect(service.getSession().isLoggedIn).toBe(true);
+    });
+
+    it('does not fire when restore establishes no session', async () => {
+      const established: AuthUser[] = [];
+      const { service } = createService({
+        onSessionStarted: async (user) => {
+          established.push(user);
+        },
+      });
+
+      await service.restoreSession();
+
+      expect(established).toHaveLength(0);
+      expect(service.getSession().isLoggedIn).toBe(false);
+    });
+
+    it('re-provisions on a later restore when a prior establish left it owed', async () => {
+      const storage = createStorage();
+      withTokens(storage);
+      let attempts = 0;
+      const { service } = createService({
+        storage,
+        onSessionStarted: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error('provision failed');
+          }
+        },
+      });
+
+      await expect(service.restoreSession()).rejects.toThrow(
+        'provision failed',
+      );
+      // The session is already established; the retry must still re-provision.
+      await service.restoreSession();
+
+      expect(attempts).toBe(2);
+      expect(service.getSession().isLoggedIn).toBe(true);
+    });
   });
 
   describe('restoreSession', () => {

--- a/packages/wallet-sdk/domain/user/auth-service.ts
+++ b/packages/wallet-sdk/domain/user/auth-service.ts
@@ -14,7 +14,13 @@ import {
   type GuestAccountStorage,
   createGuestAccountStorage,
 } from '../../lib/guest-account-storage';
-import type { AuthApi, AuthSession, AuthStorage, Logger } from '../sdk';
+import type {
+  AuthApi,
+  AuthSession,
+  AuthStorage,
+  AuthUser,
+  Logger,
+} from '../sdk';
 import type { WalletEventEmitter } from '../sdk/events';
 
 // Keys are owned by @agicash/opensecret's token persistence; the service reads
@@ -57,6 +63,15 @@ type AuthServiceDeps = {
   events: WalletEventEmitter;
   /** Per-session cache cleanup on any session end (sign-out or expiry). */
   onSessionEnded?: () => void;
+  /**
+   * Notifies the higher layer that a session settled onto its current user — the
+   * session snapshot + keys are that settled identity — on every session-started
+   * transition. The higher layer decides what that means (today: provision the
+   * user). A terminal failure from the callback rejects and propagates to the
+   * caller (the auth verb, or `init()` on restore) so the host surfaces its error
+   * boundary; the session is kept.
+   */
+  onSessionStarted?: (authUser: AuthUser) => Promise<void>;
   logger: Logger;
 };
 
@@ -108,7 +123,11 @@ export class AuthService implements AuthApi {
     if (this.session.isLoggedIn) {
       // A sign-in (or another auth action) already established the session and
       // a preceding session end un-memoized the restore; booting from storage
-      // now would only repeat the user fetch that action already did.
+      // now would only repeat the user fetch that action already did. Still
+      // (re)notify that the session started: a prior notify whose downstream
+      // provisioning threw left it owed, and the higher layer's fingerprint guard
+      // makes this a no-op once provisioning has succeeded.
+      await this.notifySessionStarted();
       return;
     }
     const [accessToken, refreshToken] = await Promise.all([
@@ -145,6 +164,11 @@ export class AuthService implements AuthApi {
       this.endSession();
       throw error;
     }
+    // Restore started the session → notify the higher layer. A terminal failure
+    // from the callback propagates through init() so the host surfaces the error
+    // boundary; the session stays (it is not a restore failure that boots
+    // anonymous).
+    await this.notifySessionStarted();
   }
 
   async signUp(email: string, password: string): Promise<void> {
@@ -273,8 +297,11 @@ export class AuthService implements AuthApi {
     context: string,
     scope?: AbortSignal,
   ): Promise<boolean> {
+    let applied: boolean;
     try {
-      return await this.applySessionFromServer(scope ? { scope } : undefined);
+      applied = await this.applySessionFromServer(
+        scope ? { scope } : undefined,
+      );
     } catch (error) {
       // An auth action whose fetchUser fails leaves an anonymous session the
       // host discovers on its next read. endSession (not a bare snapshot clear)
@@ -285,6 +312,21 @@ export class AuthService implements AuthApi {
       this.endSession();
       return true;
     }
+    if (applied) {
+      await this.notifySessionStarted();
+    }
+    return applied;
+  }
+
+  // Notifies the higher layer that a session started onto its current user; that
+  // layer decides what it means (today: provision the user). A terminal failure
+  // from the callback propagates to the caller (the auth verb, or init() on
+  // restore) so the host surfaces its error boundary; the session is kept.
+  private async notifySessionStarted(): Promise<void> {
+    if (!this.session.isLoggedIn) {
+      return;
+    }
+    await this.deps.onSessionStarted?.(this.session.user);
   }
 
   /**

--- a/packages/wallet-sdk/domain/user/user-api.test.ts
+++ b/packages/wallet-sdk/domain/user/user-api.test.ts
@@ -163,7 +163,7 @@ describe('createUserApi', () => {
   });
 
   describe('provision', () => {
-    it('upserts with the derived keys and terms, returning the user and accounts', async () => {
+    it('upserts with the derived keys, returning the user and accounts', async () => {
       const { db, calls } = createUpsertDbFake([{ ok: true }]);
       const api = createUserApi({
         db,
@@ -172,16 +172,13 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      const result = await api.provision({
-        termsAcceptedAt: '2026-01-02T00:00:00Z',
-      });
+      const result = await api.provision();
 
       expect(calls).toHaveLength(1);
       expect(calls[0]?.p_user_id).toBe('user-a');
       expect(calls[0]?.p_cashu_locking_xpub).toBe('xpub');
       expect(calls[0]?.p_encryption_public_key).toBe('enc-pub');
       expect(calls[0]?.p_spark_identity_public_key).toBe('spark-id');
-      expect(calls[0]?.p_terms_accepted_at).toBe('2026-01-02T00:00:00Z');
       expect(result.user.id).toBe('user-a');
       expect(result.accounts).toEqual([]);
     });
@@ -220,7 +217,7 @@ describe('createUserApi', () => {
           }) as unknown as AccountRepository,
       });
 
-      const result = await api.provision({});
+      const result = await api.provision();
 
       expect(calls).toHaveLength(1);
       expect(toAccountCalls).toEqual([row]);
@@ -255,15 +252,15 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      const first = await api.provision({});
-      const second = await api.provision({});
+      const first = await api.provision();
+      const second = await api.provision();
 
       expect(calls).toHaveLength(2);
       expect(first.user.username).toBe('name');
       expect(second.user.username).toBe('renamed');
     });
 
-    it('carries the terms params into the upsert on every call', async () => {
+    it('does not pass terms into the upsert — terms are decoupled to acceptTerms', async () => {
       const { db, calls } = createUpsertDbFake([{ ok: true }]);
       const api = createUserApi({
         db,
@@ -272,17 +269,11 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      await api.provision({ termsAcceptedAt: 't1' });
-      await api.provision({
-        termsAcceptedAt: 't2',
-        giftCardMintTermsAcceptedAt: 'g2',
-      });
+      await api.provision();
 
-      expect(calls).toHaveLength(2);
-      expect(calls[0]?.p_terms_accepted_at).toBe('t1');
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.p_terms_accepted_at).toBeUndefined();
       expect(calls[0]?.p_gift_card_mint_terms_accepted_at).toBeUndefined();
-      expect(calls[1]?.p_terms_accepted_at).toBe('t2');
-      expect(calls[1]?.p_gift_card_mint_terms_accepted_at).toBe('g2');
     });
 
     it('retries a transient key-derivation failure before upserting', async () => {
@@ -303,7 +294,7 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      const result = await api.provision({});
+      const result = await api.provision();
 
       expect(attempts).toBe(2);
       expect(calls).toHaveLength(1);
@@ -323,7 +314,7 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      const result = await api.provision({});
+      const result = await api.provision();
 
       expect(calls).toHaveLength(2);
       expect(result.user.id).toBe('user-a');
@@ -340,7 +331,7 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      await expect(api.provision({})).rejects.toBe(zodError);
+      await expect(api.provision()).rejects.toBe(zodError);
       expect(calls).toHaveLength(1);
     });
 
@@ -353,7 +344,7 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      await expect(api.provision({})).rejects.toThrow();
+      await expect(api.provision()).rejects.toThrow();
     });
 
     it('rejects with SessionEndedError and issues no upsert when the session ends before the write', async () => {
@@ -372,7 +363,7 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      await expect(api.provision({})).rejects.toBeInstanceOf(SessionEndedError);
+      await expect(api.provision()).rejects.toBeInstanceOf(SessionEndedError);
       expect(calls).toHaveLength(0);
     });
 
@@ -401,7 +392,31 @@ describe('createUserApi', () => {
         getAccountRepository,
       });
 
-      await expect(api.provision({})).rejects.toBeInstanceOf(SessionEndedError);
+      await expect(api.provision()).rejects.toBeInstanceOf(SessionEndedError);
+    });
+  });
+
+  describe('acceptTerms', () => {
+    it('records the real click timestamps the host passes, not now()', async () => {
+      let updatedData: Record<string, unknown> = {};
+      const api = createUserApi({
+        db: createDbFake((_filters, data) => {
+          updatedData = data;
+        }),
+        getSession: () => ({ isLoggedIn: true, user: authUser('user-a') }),
+        keys: fakeKeys(),
+        getAccountRepository,
+      });
+
+      await api.acceptTerms({
+        walletTermsAcceptedAt: '2026-01-02T03:04:05Z',
+        giftCardMintTermsAcceptedAt: '2026-01-03T00:00:00Z',
+      });
+
+      expect(updatedData.terms_accepted_at).toBe('2026-01-02T03:04:05Z');
+      expect(updatedData.gift_card_mint_terms_accepted_at).toBe(
+        '2026-01-03T00:00:00Z',
+      );
     });
   });
 });

--- a/packages/wallet-sdk/domain/user/user-api.ts
+++ b/packages/wallet-sdk/domain/user/user-api.ts
@@ -86,13 +86,11 @@ export function createUserApi(deps: Deps): UserApi {
     get: async () => readRepository.get(requireUserId()),
     updateUsername: async (username) =>
       updateRepository.update(requireUserId(), { username }),
-    acceptTerms: async (params) => {
-      const now = new Date().toISOString();
-      return updateRepository.update(requireUserId(), {
-        termsAcceptedAt: params.walletTerms ? now : undefined,
-        giftCardMintTermsAcceptedAt: params.giftCardTerms ? now : undefined,
-      });
-    },
+    acceptTerms: async (params) =>
+      updateRepository.update(requireUserId(), {
+        termsAcceptedAt: params.walletTermsAcceptedAt,
+        giftCardMintTermsAcceptedAt: params.giftCardMintTermsAcceptedAt,
+      }),
     setDefaultCurrency: async (params) =>
       updateRepository.update(requireUserId(), {
         defaultCurrency: params.currency,
@@ -101,7 +99,7 @@ export function createUserApi(deps: Deps): UserApi {
       userService.setDefaultAccount(requireUserId(), params.account, {
         setDefaultCurrency: params.setDefaultCurrency,
       }),
-    provision: async (params) => {
+    provision: async () => {
       const session = deps.getSession();
       if (!session.isLoggedIn) {
         throw new NoSessionError();
@@ -155,8 +153,6 @@ export function createUserApi(deps: Deps): UserApi {
               cashuLockingXpub,
               encryptionPublicKey,
               sparkIdentityPublicKey,
-              termsAcceptedAt: params.termsAcceptedAt,
-              giftCardMintTermsAcceptedAt: params.giftCardMintTermsAcceptedAt,
             },
             { abortSignal: signal },
           ),


### PR DESCRIPTION
## Summary

Moves provisioning into the SDK on the auth lifecycle and adds a `session.established` event so the host seeds its caches by plain reads. Removes the web-side provisioning orchestration.

## SDK

- Provision runs internally on every auth-established transition (signUp / signInGuest / signIn / restore / mid-session identity change), fired **post-establish** — as the settled current identity, never mid-switch — and guarded by an in-memory fingerprint `(userId, email, emailVerified)` so it re-runs only on identity change.
- Master's failure behavior is preserved exactly: upsert with `withRetry` (2×), no retry on `ZodError`, terminal failure **throws**. On restore that surfaces the error boundary, as live does today.
- New `session.established` event `{ user, accounts }` with **replay-latest** (a late subscriber gets the current payload immediately); cleared on session end.
- `acceptTerms(timestamp)` decoupled from provision — the host stamps the real click timestamp.
- `accounts.list()` and `session.established` return bare `Account[]`; `getExtendedAccounts` stays exported as a caller-side selector for `isDefault`. See #1170 for the deferred design that would make `isDefault` a first-class SDK-owned field with change notification.

## Web

- Deleted the `hasUserChanged` gate and `ensureUserData`'s provisioning call from `_protected.tsx` — provisioning is SDK-internal now.
- New `session.established` consumer seeds `UserCache` + `AccountsCache` from the event at boot.
- Pending pre-login terms replayed via `acceptTerms` with the real click timestamp.
- Restore path re-throws a terminal provision failure to the error boundary (matches live); boots anonymous only on a true restore failure.

## Verification

- `fix:all` clean · wallet-sdk 132 pass / 0 fail + typecheck green · web 38 pass / 0 fail + typecheck green.
- Regressions covered red-on-revert: restore re-provision after a prior failure; same-user in-tab re-login re-emits `session.established` (fingerprint + retained-event reset on session end).

## Sequencing

Merges into `sdk/accounts-slice`; accounts-slice + #1167 then go to master as one whole.
