### PR TITLE
feat(wallet-sdk): cashu receive quote slice (step 9)

### DIFF
--- a/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
@@ -39,6 +39,7 @@ import {
 } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAccountRepository } from '~/features/accounts/account-repository-hooks';
+import { sdk } from '~/features/shared/sdk.client';
 import { useOnMeltQuoteStateChange } from '~/lib/cashu/melt-quote-subscription';
 import { MintQuoteSubscriptionManager } from '~/lib/cashu/mint-quote-subscription-manager';
 import { useLatest } from '~/lib/use-latest';
@@ -182,8 +183,6 @@ export function usePendingCashuReceiveQuotesCache() {
 }
 
 export function useCreateCashuReceiveQuote() {
-  const userId = useUser((user) => user.id);
-  const cashuReceiveQuoteService = useCashuReceiveQuoteService();
   const cashuReceiveQuoteCache = useCashuReceiveQuoteCache();
 
   return useMutation({
@@ -197,16 +196,13 @@ export function useCreateCashuReceiveQuote() {
       purpose,
       transferId,
     }: CreateProps) => {
-      const lightningQuote = await cashuReceiveQuoteService.getLightningQuote({
-        wallet: account.wallet,
+      const lightningQuote = await sdk.receive.cashu.getLightningQuote({
+        account,
         amount,
         description,
       });
-
-      return cashuReceiveQuoteService.createReceiveQuote({
-        userId,
+      return sdk.receive.cashu.createQuote({
         account,
-        receiveType: 'LIGHTNING',
         lightningQuote,
         purpose,
         transferId,
@@ -248,12 +244,11 @@ export function useTrackCashuReceiveQuote({
   const enabled = !!quoteId;
   const onPaidRef = useLatest(onPaid);
   const onExpiredRef = useLatest(onExpired);
-  const cashuReceiveQuoteRepository = useCashuReceiveQuoteRepository();
 
   const { data } = useQuery({
     queryKey: [CashuReceiveQuoteCache.Key, quoteId],
     // biome-ignore lint/style/noNonNullAssertion: quoteId is guaranteed by enabled
-    queryFn: () => cashuReceiveQuoteRepository.get(quoteId!),
+    queryFn: () => sdk.receive.cashu.getQuote(quoteId!),
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',

--- a/docs/superpowers/plans/2026-08-13-wallet-sdk-cashu-receive-quote-slice.md
+++ b/docs/superpowers/plans/2026-08-13-wallet-sdk-cashu-receive-quote-slice.md
@@ -1,0 +1,216 @@
+# Wallet SDK Cashu Receive Quote Slice (Step 9) Implementation Plan
+
+> **Orchestration note:** tasks 1–4 are delivered as maxplayer marketplace **contribution-mode** jobs: the seller forks `https://github.com/MakePrisms/agicash.git` pinned to the base commit of branch `sdk/cashu-receive-quote-slice`, reads this plan and the referenced code in the fork, edits only the task's declared files, and delivers a branch descending from the base. Job text stays task-only; this document is the full spec. Tasks 0 and 5 run locally. The post-integration adversarial-review job and the PR-description job also run on the marketplace.
+
+**Goal:** Wire the `receive.cashu` sub-namespace of the SDK contract and flip the web cashu-receive-quote creation/tracking from `@agicash/wallet-sdk/temporary` to `sdk.receive.cashu.*`.
+
+**Architecture:** Step 9 of the 19-step no-cache extraction (spec: `docs/superpowers/specs/2026-06-24-wallet-sdk-no-cache-production-design.md`). The already-moved `domain/receive` cashu-receive-quote code gets a session-fenced API factory (`createReceiveApi`), the `AgicashSdk` constructor wires it (replacing the `NotImplementedError` getter), and the web receive flow calls `sdk.receive.cashu.*`. This is a **money-path slice**: the web background processor (`useProcessCashuReceiveQuoteTasks`) keeps completing, expiring, failing, and melt-initiating quotes through `/temporary` until step 18 — exactly like the realtime echo in step 8.
+
+**Tech stack:** TypeScript, bun workspaces, bun:test, Supabase (postgrest-js), TanStack Query v5 (web side only).
+
+## Global constraints
+
+- The SDK stays React-agnostic: `packages/wallet-sdk` never imports `react` or `@tanstack/react-query`.
+- Do not touch other domains' `/temporary` imports — only the files listed in this plan.
+- The web money-path boundary stays intact: `useProcessCashuReceiveQuoteTasks`, `useCashuReceiveQuoteChangeHandlers`, `usePendingCashuReceiveQuotes`, and the `useCashuReceiveQuoteRepository`/`useCashuReceiveQuoteService` hook exports keep building `/temporary` classes until step 18.
+- No event emission from the receive API. `cashu-receive-quote.created`/`.updated` stay type-only until the step-18 realtime feed (contacts + transactions precedent). `events.ts` is untouched.
+- Package manager: `bun` / `bunx` only.
+- Base branch: `master`. Work branch: `sdk/cashu-receive-quote-slice`.
+- No DB schema changes, no dependency changes. All RPCs (`create_cashu_receive_quote` etc.) are used unchanged.
+- `packages/wallet-sdk/domain/sdk/sdk.test.ts` has no receive assertions — leave it untouched.
+- `packages/wallet-sdk/index.ts` is untouched: `export * from './domain/sdk'` already carries the filled param types; `CashuReceiveQuote` (line 92) and `CashuReceiveLightningQuote` (line 93) are already exported.
+
+## Resolved design decisions
+
+1. **Contract params filled in `domain/sdk/receive.ts`** (replacing the two step-9 `unknown` placeholders; spark/cashuToken placeholders stay): `GetCashuReceiveLightningQuoteParams = { accountId, amount: Money, description? }`, `CreateCashuReceiveQuoteParams = { accountId, lightningQuote: CashuReceiveLightningQuote, purpose?: TransactionPurpose, transferId? }`. `receiveType` is pinned to `'LIGHTNING'` inside the API — `CASHU_TOKEN` quotes are created only by the in-package flows (steps 12/16/17: `receive-cashu-token-quote-service`, `transfer-service`, `lightning-address-service`), never by the host.
+2. **`createReceiveApi` in `domain/receive/receive-api.ts` returns the full `ReceiveApi`** with `cashu` implemented and `spark`/`cashuToken` as throwing getters (`NotImplementedError('receive.spark')` / `('receive.cashuToken')`), so the step-11/12 slices fill them without reshaping `sdk.ts`. `sdk.ts` deletes the `get receive()` getter and assigns `readonly receive` in the constructor via `createReceiveApi({ db, getSession: getLiveSession, keys, getAccountRepository: accounts.getRepository })` — the accounts bridge, same as `createUserApi` (sdk.ts:168).
+3. **`CashuCryptography` is assembled from session keys inside the factory** (first SDK-side assembly; the web builds its own from TanStack caches): `getSeed: () => keys.getCashuSeed()` (memoized + session-fenced), `getXpub: async (path) => deriveCashuXpub(await keys.getCashuSeed(), path)` (pure re-derivation; for the base locking path this equals `keys.getCashuLockingXpub()` output), `getPrivateKey: getCashuPrivateKey` (direct Open Secret read; only reachable through `completeReceive`, which no step-9 contract method calls — the processor path stays web-side until step 18).
+4. **Account resolution by id through the accounts bridge**: each cashu method that needs the account calls `(await deps.getAccountRepository()).get(accountId, { abortSignal })`. `null` → `NotFoundError('Account not found')`; `type !== 'cashu'` → `Error('Account is not a cashu account')`. The fetched `CashuAccount` is structurally assignable to `RedactedCashuAccount` (`RedactedAccount = DistributedOmit<Account, 'proofs'>` keeps `wallet`), so it passes to `createReceiveQuote` directly and `account.wallet` feeds `getLightningQuote`.
+5. **Latency parity note (accepted):** quote creation becomes `getLightningQuote` + `createQuote`, each fetching the account fresh (DB read + wallet init) instead of using the web's cached wallet. This is the no-cache design working as intended — reads hit the DB; flipped account reads have behaved this way since step 6.
+6. **Session fences follow the accounts template** (fence order of `accounts-api.ts:51–62`): capture `sessionSignal()` → await the repository/service deps → re-check → call with `abortSignal` where the layer accepts it → re-check. `CashuReceiveQuoteService.createReceiveQuote` gains an optional second param `options?: { abortSignal?: AbortSignal }` threaded to `repository.create` — backward-compatible; the in-package callers (transfer-service.ts:210, receive-cashu-token-quote-service.ts:139, lightning-address-service.ts:201) are unchanged. `getLightningQuote` performs mint HTTP calls that cashu-ts cannot abort — pre/post signal checks only.
+7. **`requireUserId()` only where the repository needs it**: `createQuote` (the `userId` column). `getQuote` is id-scoped (RLS enforces ownership; `transactions.get`/`contacts.get` precedent). `getLightningQuote` has no explicit session check — the session-keys getters already reject after session end.
+8. **Web flip is confined to two hooks in `cashu-receive-quote-hooks.ts`**: `useCreateCashuReceiveQuote` (mutation body → `sdk.receive.cashu.getLightningQuote` + `createQuote`; the hook's external `CreateProps` API is unchanged, so `receive-cashu.tsx` and `buy-provider.tsx` callers are untouched) and `useTrackCashuReceiveQuote` (`queryFn` → `sdk.receive.cashu.getQuote`). Everything else in the file stays: caches, change handlers, `usePendingCashuReceiveQuotes`, `useProcessCashuReceiveQuoteTasks`, and the repository/service hook exports (still consumed by the processor, `transfer-service-hooks.ts`, `receive-cashu-token-hooks.ts`, and `transaction-additional-details.tsx`).
+9. **Untouched laggard consumers** (each has its own slice): `transaction-additional-details.tsx` (`getByTransactionId` is not on the contract), `transfer-service-hooks.ts` (step 16), `receive-cashu-token-hooks.ts` + `_protected.receive.cashu_.token.tsx` (step 12), `spark-receive-quote-hooks.ts` (step 11), `cashu-receive-quote-*.server.ts` (step 17).
+10. **Canary prunes the dead cashu-receive-quote re-exports in `temporary.ts`**: the `CashuReceiveQuoteSchema` line and the `{ computeTotalFee, deriveNut20LockingPublicKey }` block from `./domain/receive/cashu-receive-quote-core` — zero repo-wide importers. `AgicashDbCashuReceiveQuote`, `getInitializedCashuWallet`, `CashuReceiveQuoteRepository`, and `CashuReceiveQuoteService` stay (live consumers listed in decision 8/9).
+11. **No SDK events, no root-index changes, no `sdk.test.ts` changes** (see Global constraints).
+
+## Delegation map (maxplayer, contribution mode)
+
+| Task | Route | Deliverable files |
+|---|---|---|
+| 0 branch + plan commit + push | local | — |
+| 1 canary: prune dead cashu-receive-quote `/temporary` exports | contribution | `packages/wallet-sdk/temporary.ts` |
+| 2 SDK: contract params + receive-api + service options param + sdk.ts wiring | contribution | 4 files (see Task specs) |
+| 3 SDK: receive-api tests | contribution | `packages/wallet-sdk/domain/receive/receive-api.test.ts` |
+| 4 web flip: two hooks → `sdk.receive.cashu` | contribution | `apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts` |
+| 5 integration, gates, smoke (live testnut receive) | local | — |
+| 6 adversarial review of the integrated diff | marketplace | findings report |
+| 7 PR description | marketplace | PR body markdown |
+
+Jobs 1–4 are posted in parallel against the same base commit (this plan commit on `sdk/cashu-receive-quote-slice`). The pinned seams below are authoritative: the test and web-flip jobs compile against the pinned contract, not job 2's delivery. Each job edits ONLY its declared files. The orchestrator verifies each delivered tree against the base (`git archive` + `diff -rq`; changed set must equal the declared set), integrates, and runs the local gates. Failed deliveries: log, re-route or do locally.
+
+## Pinned seams (authoritative for jobs 2–4)
+
+Contract (`packages/wallet-sdk/domain/sdk/receive.ts`) — replace only the two step-9 placeholder lines with:
+
+```ts
+export type GetCashuReceiveLightningQuoteParams = {
+  /** ID of the cashu account to receive into. */
+  accountId: string;
+  /** The amount to receive. */
+  amount: Money;
+  /** The description of the receive request. */
+  description?: string;
+};
+
+export type CreateCashuReceiveQuoteParams = {
+  /** ID of the cashu account to receive into. */
+  accountId: string;
+  /** The lightning quote to create the receive quote from (see `getLightningQuote`). */
+  lightningQuote: CashuReceiveLightningQuote;
+  /** The purpose of the transaction. When not provided, PAYMENT is used. */
+  purpose?: TransactionPurpose;
+  /** UUID linking paired send/receive transactions in a transfer. */
+  transferId?: string;
+};
+```
+
+with two new type-only imports: `import type { Money } from '@agicash/money';` and `import type { TransactionPurpose } from '../transactions/transaction-enums';`. The spark/cashuToken placeholder types and everything else in the file stay byte-identical.
+
+API factory (`packages/wallet-sdk/domain/receive/receive-api.ts`, new file):
+
+```ts
+type Deps = {
+  db: AgicashDb;
+  getSession: () => AuthSession;
+  keys: SessionKeys;
+  /** Accounts bridge; resolves the receiving account (sdk.ts wires accounts.getRepository). */
+  getAccountRepository: () => Promise<AccountRepository>;
+  /** Test seam; defaults to building the repository from db + session keys + account repository. */
+  createRepository?: () => Promise<CashuReceiveQuoteRepository>;
+  /** Test seam; defaults to building the service from session-keys cryptography + the repository. */
+  createService?: () => Promise<CashuReceiveQuoteService>;
+};
+
+export function createReceiveApi(deps: Deps): ReceiveApi;
+```
+
+Method bodies (fence order pinned):
+
+```ts
+getLightningQuote: async (params) => {
+  const signal = deps.keys.sessionSignal();
+  const service = await getService();
+  const account = await getCashuAccount(params.accountId, signal);
+  const quote = await service.getLightningQuote({
+    wallet: account.wallet,
+    amount: params.amount,
+    description: params.description,
+  });
+  if (signal.aborted) throw new SessionEndedError();
+  return quote;
+},
+createQuote: async (params) => {
+  const userId = requireUserId();
+  const signal = deps.keys.sessionSignal();
+  const service = await getService();
+  const account = await getCashuAccount(params.accountId, signal);
+  const quote = await service.createReceiveQuote(
+    {
+      userId,
+      account,
+      receiveType: 'LIGHTNING',
+      lightningQuote: params.lightningQuote,
+      purpose: params.purpose,
+      transferId: params.transferId,
+    },
+    { abortSignal: signal },
+  );
+  if (signal.aborted) throw new SessionEndedError();
+  return quote;
+},
+getQuote: async (id) => {
+  const signal = deps.keys.sessionSignal();
+  const repository = await getRepository();
+  if (signal.aborted) throw new SessionEndedError();
+  const quote = await repository.get(id, { abortSignal: signal });
+  if (signal.aborted) throw new SessionEndedError();
+  return quote;
+},
+```
+
+`getCashuAccount(accountId, signal)` is a factory-scoped helper: `await deps.getAccountRepository()` → re-check signal → `repository.get(accountId, { abortSignal: signal })` → re-check signal → `null` → `NotFoundError('Account not found')` → `account.type !== 'cashu'` → `Error('Account is not a cashu account')` → returns `CashuAccount`. `requireUserId()` is verbatim from `transactions-api.ts:16–22`. The `cryptography` const follows decision 3. `spark`/`cashuToken` are throwing getters typed `ReceiveApi['spark']` / `ReceiveApi['cashuToken']`.
+
+Service signature change (`packages/wallet-sdk/domain/receive/cashu-receive-quote-service.ts`):
+
+```ts
+async createReceiveQuote(
+  params: CreateQuoteParams,
+  options?: { abortSignal?: AbortSignal },
+): Promise<CashuReceiveQuote>
+```
+
+with both `this.cashuReceiveQuoteRepository.create(...)` calls gaining `options` as the second argument. Nothing else in the service changes.
+
+Wiring (`packages/wallet-sdk/domain/sdk/sdk.ts`): delete the `get receive()` getter; add `readonly receive: ReceiveApi;` alongside the other readonly namespaces; assign in the constructor tail after `this.transactions`:
+
+```ts
+this.receive = createReceiveApi({
+  db,
+  getSession: getLiveSession,
+  keys,
+  getAccountRepository: accounts.getRepository,
+});
+```
+
+`NotImplementedError` stays imported (other getters still throw it).
+
+Web flip (`apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts`): add `import { sdk } from '~/features/shared/sdk.client';`. In `useCreateCashuReceiveQuote`, delete the `useUser`/`useCashuReceiveQuoteService` locals and replace the mutation body:
+
+```ts
+mutationFn: async ({ account, amount, description, purpose, transferId }: CreateProps) => {
+  const lightningQuote = await sdk.receive.cashu.getLightningQuote({
+    accountId: account.id,
+    amount,
+    description,
+  });
+  return sdk.receive.cashu.createQuote({
+    accountId: account.id,
+    lightningQuote,
+    purpose,
+    transferId,
+  });
+},
+```
+
+In `useTrackCashuReceiveQuote`, delete the repository local and use `queryFn: () => sdk.receive.cashu.getQuote(quoteId!)` (keep the biome-ignore comment for the non-null assertion). No other hook, cache, type, or import in the file changes (`useUser` stays — `usePendingCashuReceiveQuotes` uses it).
+
+## File map
+
+- Modify: `packages/wallet-sdk/temporary.ts` (canary prune, task 1)
+- Modify: `packages/wallet-sdk/domain/sdk/receive.ts` (contract params, task 2)
+- Create: `packages/wallet-sdk/domain/receive/receive-api.ts` (task 2)
+- Modify: `packages/wallet-sdk/domain/receive/cashu-receive-quote-service.ts` (options param, task 2)
+- Modify: `packages/wallet-sdk/domain/sdk/sdk.ts` (wire the namespace, task 2)
+- Create: `packages/wallet-sdk/domain/receive/receive-api.test.ts` (task 3)
+- Modify: `apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts` (task 4)
+- Untouched on purpose: `packages/wallet-sdk/index.ts`, `domain/sdk/index.ts`, `domain/sdk/events.ts`, `sdk.test.ts`, `cashu-receive-quote-repository.ts`, `cashu-receive-quote-core.ts`, `cashu-receive-quote.ts`, both `*.server.ts` files, all web `.tsx` components, `task-processing.ts`, `use-track-wallet-changes.ts`, `sdk.client.ts`, all RPCs and migrations.
+
+## Task specs (read by contribution-mode sellers)
+
+**Task 1 (canary prune).** In `packages/wallet-sdk/temporary.ts`, delete exactly two export statements: `export { CashuReceiveQuoteSchema } from './domain/receive/cashu-receive-quote';` and the block `export { computeTotalFee, deriveNut20LockingPublicKey } from './domain/receive/cashu-receive-quote-core';`. Before deleting, verify with a repo-wide grep that no file imports these three names from `@agicash/wallet-sdk/temporary` (the spark-core exports of the same-named `computeQuoteExpiry`/`getLightningQuote` are a different block — do not touch it). Gate: `bun install && bun run fix:all && bun run typecheck` all exit 0.
+
+**Task 2 (SDK namespace).** Apply the pinned seams above to the four files in the file map. Read `domain/transactions/transactions-api.ts` and `domain/accounts/accounts-api.ts` first — `receive-api.ts` follows their structure, naming, and JSDoc style. Imports for `receive-api.ts`: `AgicashDb` from `../../db/database`; `NoSessionError`, `NotFoundError`, `NotImplementedError`, `SessionEndedError` from `../../lib/error`; `CashuCryptography`, `getCashuPrivateKey` from `../../lib/cashu`; `deriveCashuXpub` from `../../lib/cryptography`; `AuthSession`, `ReceiveApi` types from `../sdk`; `SessionKeys` from `../sdk/session-keys`; `AccountRepository` from `../accounts/account-repository`; `CashuAccount` from `../accounts/account`; `CashuReceiveQuoteRepository` / `CashuReceiveQuoteService` from their files. Gate: `bun install && bun run fix:all && bun run typecheck` all exit 0 (the service's in-package callers must still compile).
+
+**Task 3 (tests).** Create `packages/wallet-sdk/domain/receive/receive-api.test.ts` with bun:test, mirroring the harness style of `domain/transactions/transactions-api.test.ts` and `domain/accounts/accounts-api.test.ts` (fake `getSession`, fake `SessionKeys` with a controllable `sessionSignal`, seam injection via `createRepository`/`createService`/`getAccountRepository`). Compile against the pinned seams in this plan, not task 2's delivery. Required coverage: (a) `createQuote` throws `NoSessionError` when the session is not logged in, before any repository work; (b) `createQuote` happy path passes `{ userId, account, receiveType: 'LIGHTNING', lightningQuote, purpose, transferId }` and `{ abortSignal }` to the service; (c) `createQuote` rejects with `SessionEndedError` when the signal aborts during repository/service construction (mid-write fence) and the service is never called; (d) `getLightningQuote` resolves the account by id and calls the service with `{ wallet, amount, description }`; (e) `getLightningQuote` throws `NotFoundError` for a missing account and `Error` for a non-cashu account; (f) `getQuote` returns the repository result including `null` and threads the abort signal; (g) `getQuote` rejects with `SessionEndedError` when the signal is aborted; (h) accessing `receive.spark` and `receive.cashuToken` throws `NotImplementedError`. Gate: `bun install`, then from `packages/wallet-sdk`: `bun test domain/receive/receive-api.test.ts` green; `bun run fix:all && bun run typecheck` exit 0. NOTE: task 2 lands in parallel — if `receive-api.ts` does not exist in your fork, still write the test importing `./receive-api`; the orchestrator integrates and runs the suite after both land (your gate then only needs `fix:all` formatting conformance on the new file).
+
+**Task 4 (web flip).** Apply the pinned web-flip seam to `apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts` only. The two flipped hooks must not reference `useCashuReceiveQuoteService`/`useCashuReceiveQuoteRepository` anymore; every other hook in the file stays byte-identical (the processor and change handlers are the step-18 boundary). Do not remove exports or imports that are still used elsewhere in the file. NOTE: the SDK side lands in parallel — `sdk.receive.cashu.*` may throw `NotImplementedError` in your fork; that is expected. Gate: `bun install && bun run fix:all` exit 0, plus `cd apps/web-wallet && bun run typecheck` if the SDK task has landed in your base (otherwise skip typecheck; the orchestrator gates it at integration).
+
+## Verification summary
+
+| Gate | Command | Expectation |
+|---|---|---|
+| Lint/format | `bun run fix:all` | exit 0 |
+| Types (all pkgs) | `bun run typecheck` | exit 0 |
+| Unit tests | `bun run test` | green (existing suites + new receive-api tests) |
+| Smoke | manual, browser, local stack | app boots; receive flow creates a cashu quote via `sdk.receive.cashu.*`; live testnut receive completes end-to-end (web processor mints via `/temporary`); transaction appears; no console errors |

--- a/docs/superpowers/specs/2026-06-24-wallet-sdk-no-cache-production-design.md
+++ b/docs/superpowers/specs/2026-06-24-wallet-sdk-no-cache-production-design.md
@@ -28,6 +28,14 @@ reads the DB instead of an in-memory copy — negligible. In exchange the SDK st
 simple: no resident store, no cache-coherence/version-gating, no embedded query
 engine to keep in sync.
 
+**Corollary (foreground parity):** the "only effect" claim above is a rule, not
+an observation — a flipped web flow must issue no additional network requests
+versus master. Host-facing contract methods therefore take the domain objects
+the caller already fetched (`account: CashuAccount`, not `accountId`); fetch-by-id
+inside the SDK is reserved for background/orchestrator work and server routes,
+where no caller state exists. Binding form: contract proposal → "Conventions
+across all namespaces". (Codified after the step-9 review, #1176.)
+
 ## Boundary mechanism (the spine)
 
 - `packages/wallet-sdk` holds the domain layer: `*-repository`, `*-service`,
@@ -89,6 +97,14 @@ is **step 2 (cycle-break) before step 3 (move)**.
     1. move the shared runtime (task runner + leader-election lock + change-feed) into the SDK behind the contract; web calls `sdk.background.start/stop`;
     2. port each flow's processor into the SDK one at a time;
     3. web drops its realtime layer and subscribes to SDK events to keep its cache fresh.
+    - **Split the receive/send repos + services along the host/processing line**
+      (decided in the #1176 review discussion): the background-only verbs
+      (`processPayment`/`completeReceive`/`expire`/`fail`/`markMeltInitiated` and
+      their peers) and the account row-mapper dependency move to the background
+      domain; host-facing construction (`createReceiveApi` and peers) keeps only
+      create/read with db + encryption deps. Ends the accounts-bridge threading
+      in host APIs; may shrink the `.server` repo twins. Row-mapping (`toQuote`,
+      `toAccount`) stays in one shared place so the halves cannot drift.
     - Live money-path verification is mandatory here.
 19. **Cleanup** — delete `@agicash/wallet-sdk/temporary`; route remaining consumers through the contract. Boundary now build-enforced.
 

--- a/docs/superpowers/specs/2026-07-02-wallet-sdk-contract-proposal.md
+++ b/docs/superpowers/specs/2026-07-02-wallet-sdk-contract-proposal.md
@@ -304,6 +304,16 @@ Conventions across all namespaces:
   `create*` methods persist and enter the entity into the background lifecycle
   (`createQuote`, `createSwap`, `accounts.cashu.add`). A slice never re-decides
   which is which.
+- **Callers pass the domain objects they already hold.** Host-initiated methods
+  take the full entity (`account: CashuAccount`), never an id the SDK re-fetches.
+  The host fetched the entity from its own cache, and the no-cache premise
+  (production design, "Core decision") holds only if foreground flows add no
+  reads — an in-SDK `accounts.get` costs a proofs-inclusive row read plus a
+  fresh wallet init (three mint HTTP requests) per call. Fetch-by-id is reserved
+  for paths with no caller state: background/orchestrator work (off
+  `quote.accountId` and the like) and server routes. Per-slice check: a flipped
+  web flow issues no additional network requests versus master. (Set by the
+  step-9 review, #1176; slices 10–16 follow it. A slice never re-decides this.)
 - **Completion is not the host's job.** Methods like `expire`/`fail`/
   `completeSwap` that today's hooks call from background processors do NOT
   appear on the public namespaces — they move behind `sdk.background`

--- a/packages/wallet-sdk/domain/receive/cashu-receive-quote-service.ts
+++ b/packages/wallet-sdk/domain/receive/cashu-receive-quote-service.ts
@@ -58,6 +58,7 @@ export class CashuReceiveQuoteService {
    */
   async createReceiveQuote(
     params: CreateQuoteParams,
+    options?: { abortSignal?: AbortSignal },
   ): Promise<CashuReceiveQuote> {
     const {
       userId,
@@ -93,24 +94,30 @@ export class CashuReceiveQuoteService {
     };
 
     if (receiveType === 'CASHU_TOKEN') {
-      return this.cashuReceiveQuoteRepository.create({
-        ...baseParams,
-        receiveType,
-        meltData: {
-          tokenMintUrl: params.sourceMintUrl,
-          tokenAmount: params.tokenAmount,
-          tokenProofs: params.tokenProofs,
-          meltQuoteId: params.meltQuoteId,
-          cashuReceiveFee: params.cashuReceiveFee,
-          lightningFeeReserve: params.lightningFeeReserve,
+      return this.cashuReceiveQuoteRepository.create(
+        {
+          ...baseParams,
+          receiveType,
+          meltData: {
+            tokenMintUrl: params.sourceMintUrl,
+            tokenAmount: params.tokenAmount,
+            tokenProofs: params.tokenProofs,
+            meltQuoteId: params.meltQuoteId,
+            cashuReceiveFee: params.cashuReceiveFee,
+            lightningFeeReserve: params.lightningFeeReserve,
+          },
         },
-      });
+        options,
+      );
     }
 
-    return this.cashuReceiveQuoteRepository.create({
-      ...baseParams,
-      receiveType,
-    });
+    return this.cashuReceiveQuoteRepository.create(
+      {
+        ...baseParams,
+        receiveType,
+      },
+      options,
+    );
   }
 
   /**

--- a/packages/wallet-sdk/domain/receive/receive-api.test.ts
+++ b/packages/wallet-sdk/domain/receive/receive-api.test.ts
@@ -1,0 +1,527 @@
+import { describe, expect, it } from 'bun:test';
+import { type Currency, Money } from '@agicash/money';
+import type { AgicashDb } from '../../db/database';
+import { BASE_CASHU_LOCKING_DERIVATION_PATH } from '../../lib/cashu';
+import { derivePublicKey } from '../../lib/cryptography';
+import {
+  NoSessionError,
+  NotImplementedError,
+  SessionEndedError,
+} from '../../lib/error';
+import type { CashuAccount as DomainCashuAccount } from '../accounts/account';
+import type { AccountRepository } from '../accounts/account-repository';
+import type { AuthSession, AuthUser } from '../sdk';
+import { createSessionKeys } from '../sdk/session-keys';
+import type { CashuReceiveQuote } from './cashu-receive-quote';
+import type { CashuReceiveLightningQuote } from './cashu-receive-quote-core';
+import type { CashuReceiveQuoteRepository } from './cashu-receive-quote-repository';
+import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+import { createReceiveApi } from './receive-api';
+
+const authUser = (id: string): AuthUser =>
+  ({
+    id,
+    name: null,
+    email: 'a@b.c',
+    email_verified: true,
+    login_method: 'email',
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+  }) as AuthUser;
+
+const loggedIn = (id: string): AuthSession => ({
+  isLoggedIn: true,
+  user: authUser(id),
+});
+
+const cashuDomain = (
+  overrides: Partial<Record<string, unknown>> = {},
+): DomainCashuAccount =>
+  ({
+    id: 'acct-cashu',
+    name: 'Testnut BTC',
+    type: 'cashu',
+    purpose: 'transactional',
+    state: 'active',
+    isOnline: true,
+    currency: 'BTC',
+    createdAt: '2026-01-01T00:00:00Z',
+    version: 1,
+    expiresAt: null,
+    mintUrl: 'https://testnut.cashu.space',
+    isTestMint: true,
+    keysetCounters: {},
+    proofs: [{ amount: 100 }, { amount: 50 }],
+    wallet: { marker: 'cashu-wallet' },
+    ...overrides,
+  }) as unknown as DomainCashuAccount;
+
+const makeLightningQuote = (): CashuReceiveLightningQuote =>
+  ({
+    mintQuote: {
+      quote: 'mint-quote-1',
+      request: 'lnbc100n1payme',
+      state: 'UNPAID',
+      expiry: 1767229200,
+    },
+    lockingPublicKey: '02abc',
+    fullLockingDerivationPath: "m/129372'/0'/0'/4321",
+    expiresAt: '2026-01-01T01:00:00Z',
+    amount: new Money({ amount: 100, currency: 'BTC', unit: 'sat' }),
+    description: 'test receive',
+    paymentHash: 'payment-hash-1',
+  }) as unknown as CashuReceiveLightningQuote;
+
+const makeQuote = (
+  overrides: Partial<Record<string, unknown>> = {},
+): CashuReceiveQuote =>
+  ({
+    id: 'quote-1',
+    userId: 'user-x',
+    accountId: 'acct-cashu',
+    quoteId: 'mint-quote-1',
+    amount: new Money({ amount: 100, currency: 'BTC', unit: 'sat' }),
+    createdAt: '2026-01-01T00:00:00Z',
+    expiresAt: '2026-01-01T01:00:00Z',
+    paymentRequest: 'lnbc100n1payme',
+    paymentHash: 'payment-hash-1',
+    lockingDerivationPath: "m/129372'/0'/0'/4321",
+    transactionId: 'tx-1',
+    totalFee: Money.zero('BTC'),
+    version: 1,
+    type: 'LIGHTNING',
+    state: 'UNPAID',
+    ...overrides,
+  }) as unknown as CashuReceiveQuote;
+
+const makeApi = (deps: {
+  session: AuthSession;
+  repository?: Partial<CashuReceiveQuoteRepository>;
+  service?: Partial<CashuReceiveQuoteService>;
+}) =>
+  createReceiveApi({
+    db: {} as unknown as AgicashDb,
+    keys: createSessionKeys(),
+    getSession: () => deps.session,
+    getAccountRepository: async () => ({}) as unknown as AccountRepository,
+    createRepository: async () =>
+      (deps.repository ?? {}) as unknown as CashuReceiveQuoteRepository,
+    createService: async () =>
+      (deps.service ?? {}) as unknown as CashuReceiveQuoteService,
+  });
+
+describe('createReceiveApi', () => {
+  describe('cashu.createQuote', () => {
+    it('throws NoSessionError without a session, before any repository work', async () => {
+      let createServiceCalls = 0;
+      let getAccountRepositoryCalls = 0;
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys: createSessionKeys(),
+        getSession: () => ({ isLoggedIn: false }),
+        getAccountRepository: async () => {
+          getAccountRepositoryCalls += 1;
+          return {} as unknown as AccountRepository;
+        },
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+        createService: async () => {
+          createServiceCalls += 1;
+          return {} as unknown as CashuReceiveQuoteService;
+        },
+      });
+
+      await expect(
+        api.cashu.createQuote({
+          account: cashuDomain(),
+          lightningQuote: makeLightningQuote(),
+        }),
+      ).rejects.toBeInstanceOf(NoSessionError);
+      expect(createServiceCalls).toBe(0);
+      expect(getAccountRepositoryCalls).toBe(0);
+    });
+
+    it('passes the session userId, the given account, LIGHTNING receive type, and the abort signal to the service', async () => {
+      let captured: Record<string, unknown> | undefined;
+      let capturedOptions: { abortSignal?: AbortSignal } | undefined;
+      const account = cashuDomain();
+      const lightningQuote = makeLightningQuote();
+      const quote = makeQuote();
+      const api = makeApi({
+        session: loggedIn('user-x'),
+        service: {
+          createReceiveQuote: (async (
+            params: Record<string, unknown>,
+            options?: { abortSignal?: AbortSignal },
+          ) => {
+            captured = params;
+            capturedOptions = options;
+            return quote;
+          }) as unknown as CashuReceiveQuoteService['createReceiveQuote'],
+        },
+      });
+
+      const result = await api.cashu.createQuote({
+        account,
+        lightningQuote,
+        purpose: 'TRANSFER',
+        transferId: 'transfer-1',
+      });
+
+      expect(captured?.userId).toBe('user-x');
+      expect(captured?.account).toBe(account);
+      expect(captured?.receiveType).toBe('LIGHTNING');
+      expect(captured?.lightningQuote).toBe(lightningQuote);
+      expect(captured?.purpose).toBe('TRANSFER');
+      expect(captured?.transferId).toBe('transfer-1');
+      expect(capturedOptions?.abortSignal).toBeDefined();
+      expect(result).toBe(quote);
+    });
+
+    it('rejects with SessionEndedError and never calls the service when the session ends during service construction', async () => {
+      const keys = createSessionKeys();
+      let createReceiveQuoteCalls = 0;
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+        createService: async () => {
+          // The session ends between the signal capture and the write.
+          keys.reset();
+          return {
+            createReceiveQuote: (async () => {
+              createReceiveQuoteCalls += 1;
+              return makeQuote();
+            }) as unknown as CashuReceiveQuoteService['createReceiveQuote'],
+          } as unknown as CashuReceiveQuoteService;
+        },
+      });
+
+      await expect(
+        api.cashu.createQuote({
+          account: cashuDomain(),
+          lightningQuote: makeLightningQuote(),
+        }),
+      ).rejects.toBeInstanceOf(SessionEndedError);
+      expect(createReceiveQuoteCalls).toBe(0);
+    });
+  });
+
+  describe('cashu.getLightningQuote', () => {
+    it('calls the service with the account wallet, amount, and description', async () => {
+      let captured:
+        | { wallet: unknown; amount: Money; description?: string }
+        | undefined;
+      const account = cashuDomain();
+      const lightningQuote = makeLightningQuote();
+      const api = makeApi({
+        session: loggedIn('user-x'),
+        service: {
+          getLightningQuote: (async (params: {
+            wallet: unknown;
+            amount: Money;
+            description?: string;
+          }) => {
+            captured = params;
+            return lightningQuote;
+          }) as unknown as CashuReceiveQuoteService['getLightningQuote'],
+        },
+      });
+
+      const amount = new Money<Currency>({
+        amount: 100,
+        currency: 'BTC',
+        unit: 'sat',
+      });
+      const result = await api.cashu.getLightningQuote({
+        account,
+        amount,
+        description: 'test receive',
+      });
+
+      expect(captured?.wallet).toBe(account.wallet);
+      expect(captured?.amount).toBe(amount);
+      expect(captured?.description).toBe('test receive');
+      expect(result).toBe(lightningQuote);
+    });
+  });
+
+  describe('cashu.getQuote', () => {
+    it('passes the id and the abort signal through and returns the quote verbatim', async () => {
+      let requestedId: string | undefined;
+      let capturedOptions: { abortSignal?: AbortSignal } | undefined;
+      const quote = makeQuote();
+      const api = makeApi({
+        session: loggedIn('user-x'),
+        repository: {
+          get: (async (id, options) => {
+            requestedId = id;
+            capturedOptions = options;
+            return quote;
+          }) as CashuReceiveQuoteRepository['get'],
+        },
+      });
+
+      const result = await api.cashu.getQuote('quote-1');
+
+      expect(requestedId).toBe('quote-1');
+      expect(capturedOptions?.abortSignal).toBeDefined();
+      expect(result).toBe(quote);
+    });
+
+    it('returns null when the quote does not exist', async () => {
+      const api = makeApi({
+        session: loggedIn('user-x'),
+        repository: {
+          get: (async () => null) as CashuReceiveQuoteRepository['get'],
+        },
+      });
+
+      await expect(api.cashu.getQuote('missing')).resolves.toBeNull();
+    });
+
+    it('rejects with SessionEndedError and issues no read when the session ends before the read', async () => {
+      const keys = createSessionKeys();
+      let getCalls = 0;
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () => {
+          // The session ends between the signal capture and the read.
+          keys.reset();
+          return {
+            get: (async () => {
+              getCalls += 1;
+              return makeQuote();
+            }) as CashuReceiveQuoteRepository['get'],
+          } as unknown as CashuReceiveQuoteRepository;
+        },
+        createService: async () => ({}) as unknown as CashuReceiveQuoteService,
+      });
+
+      await expect(api.cashu.getQuote('quote-1')).rejects.toBeInstanceOf(
+        SessionEndedError,
+      );
+      expect(getCalls).toBe(0);
+    });
+
+    it('rejects with SessionEndedError when the session ends during the read', async () => {
+      const keys = createSessionKeys();
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({
+            get: (async () => {
+              keys.reset();
+              return makeQuote();
+            }) as CashuReceiveQuoteRepository['get'],
+          }) as unknown as CashuReceiveQuoteRepository,
+        createService: async () => ({}) as unknown as CashuReceiveQuoteService,
+      });
+
+      await expect(api.cashu.getQuote('quote-1')).rejects.toBeInstanceOf(
+        SessionEndedError,
+      );
+    });
+  });
+
+  describe('session fences', () => {
+    it('rejects getLightningQuote with SessionEndedError and never calls the mint when the session ends during service construction', async () => {
+      const keys = createSessionKeys();
+      let getLightningQuoteCalls = 0;
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+        createService: async () => {
+          // The session ends between the signal capture and the mint call.
+          keys.reset();
+          return {
+            getLightningQuote: (async () => {
+              getLightningQuoteCalls += 1;
+              return makeLightningQuote();
+            }) as unknown as CashuReceiveQuoteService['getLightningQuote'],
+          } as unknown as CashuReceiveQuoteService;
+        },
+      });
+
+      await expect(
+        api.cashu.getLightningQuote({
+          account: cashuDomain(),
+          amount: new Money<Currency>({
+            amount: 100,
+            currency: 'BTC',
+            unit: 'sat',
+          }),
+        }),
+      ).rejects.toBeInstanceOf(SessionEndedError);
+      expect(getLightningQuoteCalls).toBe(0);
+    });
+
+    it('rejects getLightningQuote with SessionEndedError when the session ends during the mint call', async () => {
+      const keys = createSessionKeys();
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+        createService: async () =>
+          ({
+            getLightningQuote: (async () => {
+              keys.reset();
+              return makeLightningQuote();
+            }) as unknown as CashuReceiveQuoteService['getLightningQuote'],
+          }) as unknown as CashuReceiveQuoteService,
+      });
+
+      await expect(
+        api.cashu.getLightningQuote({
+          account: cashuDomain(),
+          amount: new Money<Currency>({
+            amount: 100,
+            currency: 'BTC',
+            unit: 'sat',
+          }),
+        }),
+      ).rejects.toBeInstanceOf(SessionEndedError);
+    });
+
+    it('rejects createQuote with SessionEndedError when the session ends during the write', async () => {
+      const keys = createSessionKeys();
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+        createService: async () =>
+          ({
+            createReceiveQuote: (async () => {
+              keys.reset();
+              return makeQuote();
+            }) as unknown as CashuReceiveQuoteService['createReceiveQuote'],
+          }) as unknown as CashuReceiveQuoteService,
+      });
+
+      await expect(
+        api.cashu.createQuote({
+          account: cashuDomain(),
+          lightningQuote: makeLightningQuote(),
+        }),
+      ).rejects.toBeInstanceOf(SessionEndedError);
+    });
+
+    it('threads the session signal into the service write', async () => {
+      const keys = createSessionKeys();
+      let writeSignal: AbortSignal | undefined;
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+        createService: async () =>
+          ({
+            createReceiveQuote: (async (
+              _params: unknown,
+              options?: { abortSignal?: AbortSignal },
+            ) => {
+              writeSignal = options?.abortSignal;
+              return makeQuote();
+            }) as unknown as CashuReceiveQuoteService['createReceiveQuote'],
+          }) as unknown as CashuReceiveQuoteService,
+      });
+
+      await api.cashu.createQuote({
+        account: cashuDomain(),
+        lightningQuote: makeLightningQuote(),
+      });
+
+      expect(writeSignal).toBe(keys.sessionSignal());
+    });
+  });
+
+  describe('default service cryptography', () => {
+    // BOLT11 spec test-vector invoice; the core decodes it for the payment hash.
+    const fixtureInvoice =
+      'lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp';
+
+    it('locks the mint quote to a key derived from the session cashu locking xpub', async () => {
+      const keys = createSessionKeys({
+        readCashuSeed: async () => new Uint8Array(64).fill(7),
+      });
+      const wallet = {
+        createLockedMintQuote: async (
+          amount: number,
+          pubkey: string,
+          description?: string,
+        ) => ({
+          quote: 'mint-quote-parity',
+          request: fixtureInvoice,
+          state: 'UNPAID',
+          expiry: 1767229200,
+          pubkey,
+          amount,
+          unit: 'sat',
+          description,
+        }),
+      };
+      const api = createReceiveApi({
+        db: {} as unknown as AgicashDb,
+        keys,
+        getSession: () => loggedIn('user-x'),
+        getAccountRepository: async () => ({}) as unknown as AccountRepository,
+        createRepository: async () =>
+          ({}) as unknown as CashuReceiveQuoteRepository,
+      });
+
+      const result = await api.cashu.getLightningQuote({
+        account: cashuDomain({ wallet }),
+        amount: new Money<Currency>({
+          amount: 100,
+          currency: 'BTC',
+          unit: 'sat',
+        }),
+      });
+
+      expect(
+        result.fullLockingDerivationPath.startsWith(
+          BASE_CASHU_LOCKING_DERIVATION_PATH,
+        ),
+      ).toBe(true);
+      const unhardenedIndex = result.fullLockingDerivationPath.split('/').pop();
+      expect(result.lockingPublicKey).toBe(
+        derivePublicKey(
+          await keys.getCashuLockingXpub(),
+          `m/${unhardenedIndex}`,
+        ),
+      );
+      expect(result.paymentHash).toHaveLength(64);
+      expect(result.mintQuote.quote).toBe('mint-quote-parity');
+    });
+  });
+
+  describe('spark and cashuToken', () => {
+    it('throws NotImplementedError until their slices land', () => {
+      const api = makeApi({ session: loggedIn('user-x') });
+
+      expect(() => api.spark).toThrow(NotImplementedError);
+      expect(() => api.cashuToken).toThrow(NotImplementedError);
+    });
+  });
+});

--- a/packages/wallet-sdk/domain/receive/receive-api.ts
+++ b/packages/wallet-sdk/domain/receive/receive-api.ts
@@ -1,0 +1,110 @@
+import type { AgicashDb } from '../../db/database';
+import { type CashuCryptography, getCashuPrivateKey } from '../../lib/cashu';
+import { deriveCashuXpub } from '../../lib/cryptography';
+import {
+  NoSessionError,
+  NotImplementedError,
+  SessionEndedError,
+} from '../../lib/error';
+import type { AccountRepository } from '../accounts/account-repository';
+import type { AuthSession, ReceiveApi } from '../sdk';
+import type { SessionKeys } from '../sdk/session-keys';
+import { CashuReceiveQuoteRepository } from './cashu-receive-quote-repository';
+import { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+
+type Deps = {
+  db: AgicashDb;
+  getSession: () => AuthSession;
+  keys: SessionKeys;
+  /** Accounts bridge; feeds the quote repository (sdk.ts wires accounts.getRepository). */
+  getAccountRepository: () => Promise<AccountRepository>;
+  /** Test seam; defaults to building the repository from db + session keys + account repository. */
+  createRepository?: () => Promise<CashuReceiveQuoteRepository>;
+  /** Test seam; defaults to building the service from session-keys cryptography + the repository. */
+  createService?: () => Promise<CashuReceiveQuoteService>;
+};
+
+/** Creates the `receive` SDK namespace. */
+export function createReceiveApi(deps: Deps): ReceiveApi {
+  const requireUserId = (): string => {
+    const session = deps.getSession();
+    if (!session.isLoggedIn) {
+      throw new NoSessionError();
+    }
+    return session.user.id;
+  };
+
+  const cryptography: CashuCryptography = {
+    getSeed: () => deps.keys.getCashuSeed(),
+    getXpub: async (path) =>
+      deriveCashuXpub(await deps.keys.getCashuSeed(), path),
+    getPrivateKey: getCashuPrivateKey,
+  };
+
+  const getRepository =
+    deps.createRepository ??
+    (async (): Promise<CashuReceiveQuoteRepository> => {
+      const encryption = await deps.keys.getEncryption();
+      const accountRepository = await deps.getAccountRepository();
+      return new CashuReceiveQuoteRepository(
+        deps.db,
+        encryption,
+        accountRepository,
+      );
+    });
+
+  const getService =
+    deps.createService ??
+    (async (): Promise<CashuReceiveQuoteService> =>
+      new CashuReceiveQuoteService(cryptography, await getRepository()));
+
+  return {
+    cashu: {
+      getLightningQuote: async (params) => {
+        const signal = deps.keys.sessionSignal();
+        const service = await getService();
+        if (signal.aborted) throw new SessionEndedError();
+        const quote = await service.getLightningQuote({
+          wallet: params.account.wallet,
+          amount: params.amount,
+          description: params.description,
+        });
+        if (signal.aborted) throw new SessionEndedError();
+        return quote;
+      },
+      createQuote: async (params) => {
+        const userId = requireUserId();
+        const signal = deps.keys.sessionSignal();
+        const service = await getService();
+        if (signal.aborted) throw new SessionEndedError();
+        const quote = await service.createReceiveQuote(
+          {
+            userId,
+            account: params.account,
+            receiveType: 'LIGHTNING',
+            lightningQuote: params.lightningQuote,
+            purpose: params.purpose,
+            transferId: params.transferId,
+          },
+          { abortSignal: signal },
+        );
+        if (signal.aborted) throw new SessionEndedError();
+        return quote;
+      },
+      getQuote: async (id) => {
+        const signal = deps.keys.sessionSignal();
+        const repository = await getRepository();
+        if (signal.aborted) throw new SessionEndedError();
+        const quote = await repository.get(id, { abortSignal: signal });
+        if (signal.aborted) throw new SessionEndedError();
+        return quote;
+      },
+    },
+    get spark(): ReceiveApi['spark'] {
+      throw new NotImplementedError('receive.spark');
+    },
+    get cashuToken(): ReceiveApi['cashuToken'] {
+      throw new NotImplementedError('receive.cashuToken');
+    },
+  };
+}

--- a/packages/wallet-sdk/domain/sdk/receive.ts
+++ b/packages/wallet-sdk/domain/sdk/receive.ts
@@ -1,7 +1,10 @@
+import type { Money } from '@agicash/money';
+import type { CashuAccount } from '../accounts/account';
 import type { CashuReceiveQuote } from '../receive/cashu-receive-quote';
 import type { CashuReceiveLightningQuote } from '../receive/cashu-receive-quote-core';
 import type { SparkReceiveQuote } from '../receive/spark-receive-quote';
 import type { SparkReceiveLightningQuote } from '../receive/spark-receive-quote-core';
+import type { TransactionPurpose } from '../transactions/transaction-enums';
 
 // The public receive types are the domain entities for now: only the apps
 // consume the SDK and they just read these shapes, so the extra domain fields
@@ -41,8 +44,25 @@ export type ReceiveApi = {
   };
 };
 
-export type GetCashuReceiveLightningQuoteParams = unknown; // step 9 (cashu receive quote)
-export type CreateCashuReceiveQuoteParams = unknown; // step 9 (cashu receive quote)
+export type GetCashuReceiveLightningQuoteParams = {
+  /** The cashu account to receive into. */
+  account: CashuAccount;
+  /** The amount to receive. */
+  amount: Money;
+  /** The description of the receive request. */
+  description?: string;
+};
+
+export type CreateCashuReceiveQuoteParams = {
+  /** The cashu account to receive into. */
+  account: CashuAccount;
+  /** The lightning quote to create the receive quote from (see `getLightningQuote`). */
+  lightningQuote: CashuReceiveLightningQuote;
+  /** The purpose of the transaction. When not provided, PAYMENT is used. */
+  purpose?: TransactionPurpose;
+  /** UUID linking paired send/receive transactions in a transfer. */
+  transferId?: string;
+};
 export type GetSparkReceiveLightningQuoteParams = unknown; // step 11 (spark receive quote)
 export type CreateSparkReceiveQuoteParams = unknown; // step 11 (spark receive quote)
 export type GetReceiveCashuTokenQuoteParams = unknown; // step 12 (receive cashu token)

--- a/packages/wallet-sdk/domain/sdk/sdk.ts
+++ b/packages/wallet-sdk/domain/sdk/sdk.ts
@@ -26,6 +26,7 @@ import {
 } from '../../lib/spark/wallet';
 import { createAccountsApi } from '../accounts/accounts-api';
 import { createContactsApi } from '../contacts/contacts-api';
+import { createReceiveApi } from '../receive/receive-api';
 import { createTransactionsApi } from '../transactions/transactions-api';
 import { AuthService } from '../user/auth-service';
 import { createUserApi } from '../user/user-api';
@@ -50,11 +51,9 @@ export class AgicashSdk implements Sdk {
   readonly accounts: AccountsApi;
   readonly contacts: ContactsApi;
   readonly transactions: TransactionsApi;
+  readonly receive: ReceiveApi;
   readonly events: WalletEvents;
 
-  get receive(): ReceiveApi {
-    throw new NotImplementedError('receive');
-  }
   get send(): SendApi {
     throw new NotImplementedError('send');
   }
@@ -178,6 +177,12 @@ export class AgicashSdk implements Sdk {
       db,
       getSession: getLiveSession,
       keys,
+    });
+    this.receive = createReceiveApi({
+      db,
+      getSession: getLiveSession,
+      keys,
+      getAccountRepository: accounts.getRepository,
     });
     this.events = events;
   }

--- a/packages/wallet-sdk/temporary.ts
+++ b/packages/wallet-sdk/temporary.ts
@@ -118,11 +118,6 @@ export {
 } from './domain/receive/spark-receive-quote-core';
 export { SparkReceiveQuoteRepository } from './domain/receive/spark-receive-quote-repository';
 export { SparkReceiveQuoteService } from './domain/receive/spark-receive-quote-service';
-export { CashuReceiveQuoteSchema } from './domain/receive/cashu-receive-quote';
-export {
-  computeTotalFee,
-  deriveNut20LockingPublicKey,
-} from './domain/receive/cashu-receive-quote-core';
 export { CashuReceiveQuoteRepository } from './domain/receive/cashu-receive-quote-repository';
 export { CashuReceiveQuoteService } from './domain/receive/cashu-receive-quote-service';
 export { CashuReceiveSwapSchema } from './domain/receive/cashu-receive-swap';


### PR DESCRIPTION

## Summary

Step 9 of the 19-step no-cache wallet-SDK extraction (spec: `docs/superpowers/specs/2026-06-24-wallet-sdk-no-cache-production-design.md`; plan committed in this PR: `docs/superpowers/plans/2026-08-13-wallet-sdk-cashu-receive-quote-slice.md`). This wires `sdk.receive.cashu` (`getLightningQuote` / `createQuote` / `getQuote`) and flips web cashu-receive-quote creation and tracking from `@agicash/wallet-sdk/temporary` to `sdk.receive.cashu.*`. The web background processor (`useProcessCashuReceiveQuoteTasks`) keeps completing, expiring, failing, and melt-initiating quotes through `/temporary` until step 18 — the money-path boundary stays intact.

## What changed

### SDK

- `domain/sdk/receive.ts` — fills `GetCashuReceiveLightningQuoteParams` (`account: CashuAccount`, `amount: Money`, `description?`) and `CreateCashuReceiveQuoteParams` (`account: CashuAccount`, `lightningQuote`, `purpose?`, `transferId?`), replacing the two step-9 `unknown` placeholders. Spark/cashuToken placeholders stay. (Initially shipped as `accountId` with an internal fetch; flipped to the full account in `f30a3315` after review — see r3784641517.)
- NEW `domain/receive/receive-api.ts` — `createReceiveApi(deps)` returns the full `ReceiveApi` with `cashu` implemented and session fences on the accounts template (capture `sessionSignal()`, await repository/service deps, re-check, thread `abortSignal` where the layer accepts it, re-check). `spark` / `cashuToken` remain throwing getters (`NotImplementedError('receive.spark')` / `('receive.cashuToken')`) so steps 11/12 can fill them without reshaping `sdk.ts`.
- `domain/receive/cashu-receive-quote-service.ts` — `createReceiveQuote` gains an optional second param `options?: { abortSignal?: AbortSignal }`, threaded to both `repository.create` calls. Backward-compatible; in-package callers are unchanged.
- `domain/sdk/sdk.ts` — the throwing `get receive()` getter is replaced with `readonly receive` wired via `createReceiveApi({ db, getSession: getLiveSession, keys, getAccountRepository: accounts.getRepository })`.

### Web

- `apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts` — `useCreateCashuReceiveQuote` now calls `sdk.receive.cashu.getLightningQuote` + `createQuote`; `useTrackCashuReceiveQuote` now calls `sdk.receive.cashu.getQuote`. The hooks' external APIs are unchanged, so callers are untouched. Caches, change handlers, `usePendingCashuReceiveQuotes`, `useProcessCashuReceiveQuoteTasks`, and the repository/service hook exports stay on `/temporary`.

### Canary

- `packages/wallet-sdk/temporary.ts` — two dead cashu-receive-quote re-exports pruned: `CashuReceiveQuoteSchema` and `{ computeTotalFee, deriveNut20LockingPublicKey }` from `cashu-receive-quote-core`. `AgicashDbCashuReceiveQuote`, `getInitializedCashuWallet`, `CashuReceiveQuoteRepository`, and `CashuReceiveQuoteService` stay (live consumers).

### Tests

- NEW `domain/receive/receive-api.test.ts` — `createQuote` throws `NoSessionError` before any repository work; happy path passes `{ userId, account, receiveType: 'LIGHTNING', lightningQuote, purpose, transferId }` and `{ abortSignal }` to the service; mid-construction abort yields `SessionEndedError` with the service never called (both methods); `getLightningQuote` calls the service with the given account's wallet; `getQuote` returns the repository result including `null` and threads the abort signal, and rejects with `SessionEndedError` when the signal aborts; accessing `receive.spark` / `receive.cashuToken` throws `NotImplementedError`. Wallet-sdk suite 174 green.

## Design decisions

- **`receiveType` pinned to `'LIGHTNING'`** inside the API. `CASHU_TOKEN` quotes are created only by in-package flows (steps 12/16/17: `receive-cashu-token-quote-service`, `transfer-service`, `lightning-address-service`), never by the host.
- **Caller-supplied account**: `getLightningQuote` and `createQuote` take the full `CashuAccount` in params (`f30a3315`, review r3784641517). The caller already holds the account, so the SDK does no per-call account fetch (which cost a Supabase read of the account plus all unspent proofs, proof decryption, and a fresh wallet init of three mint HTTP requests — twice per receive flow). The cashu-only constraint is compile-time; `CashuAccount` is structurally assignable to `RedactedCashuAccount` and passes to `createReceiveQuote`; `account.wallet` feeds `getLightningQuote`. Fetch-by-id remains the shape only for dark/background paths that work off `quote.accountId`. `getAccountRepository` stays a dep — it feeds the quote repository constructor.
- **`CashuCryptography` assembled from session keys** (first SDK-side assembly; the web builds its own from TanStack caches): `getSeed` / `getXpub` go through `keys.getCashuSeed()`. `getPrivateKey` is a direct Open Secret read (`getCashuPrivateKey`) and is unfenced; it is only reachable through `completeReceive`, which no step-9 contract method calls — the processor path stays web-side until step 18.
- **No events emitted**: `cashu-receive-quote.created` / `.updated` stay type-only until the step-18 realtime feed (contacts + transactions precedent). `events.ts` is untouched.
- **Latency parity (accepted)**: quote creation is now `getLightningQuote` + `createQuote`, each fetching the account fresh (DB read + wallet init) instead of using the web's cached wallet. This is the no-cache design working as intended; flipped account reads have behaved this way since step 6.
- **Untouched laggard consumers** (each has its own slice): `transaction-additional-details.tsx` (`getByTransactionId` is not on the contract); `transfer-service-hooks.ts` (step 16); `receive-cashu-token-hooks.ts` + `_protected.receive.cashu_.token.tsx` (step 12); `spark-receive-quote-hooks.ts` (step 11); `cashu-receive-quote-*.server.ts` (step 17).

## Verification

- `bun run fix:all` exit 0; `bun run typecheck` exit 0 (all packages).
- Unit tests: all green (wallet-sdk 175 pass, including 15 new receive-api tests).
- Browser smoke on the local stack: a live 21-sat testnut receive created a quote through `sdk.receive.cashu.*` and completed end-to-end through the untouched web processor (`/temporary`); zero console errors.

## Delegation note

Implementation, tests, web flip, the `temporary.ts` prune, and this description were produced as paid maxplayer marketplace jobs and integrated + verified locally by the orchestrating agent.

## Adversarial review findings and dispositions

A marketplace adversarial review of the integrated diff returned NOT READY with 0 Critical, 2 Important, and 2 Minor findings. Dispositions:

- **Important 1 — `createQuote` does not bind the `lightningQuote` preview to the account that produced it.** Kept as-is, documented for the maintainer. The pre-slice service had the same two-step shape with no origin check, and no current caller can mix accounts (the web mutation threads one account through both calls). A proper fix reshapes the maintainer-endorsed contract (`CashuReceiveLightningQuote` would carry its originating account id and `createQuote` would reject a mismatch) and equally affects the step-11 spark namespace — a contract decision to take once, not a slice-local patch.
- **Important 2 — `createQuote` re-fetches the account with wallet initialization after the mint quote already exists.** RESOLVED in `f30a3315` (review r3784641517): the params take the full `CashuAccount` and the internal account lookup is gone entirely, which removes both the re-initialization failure surface and the latency regression versus the live branch.
- **Minor 1 — missing post-operation fence coverage.** Fixed in `ca71e695`: post-op `SessionEndedError` tests for `getLightningQuote` and `createQuote`, plus a signal-identity test across the account lookup and the service write.
- **Minor 2 — the `CashuCryptography` adapter was untested.** Fixed in `ca71e695`: a default-service-path test proves the mint quote's locking key derives from the same base xpub as `SessionKeys.getCashuLockingXpub`.

An earlier review attempt was delivered blocked: the seller's harness had no shell or network, so it could not clone the repo; it reported that honestly instead of fabricating a verdict, and the review was re-run as a contribution-mode job (the seller forks the repo and reads it directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

