### PR TITLE
chore(devenv): add typescript-language-server

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -13,6 +13,7 @@
     pkgs.mkcert
     pkgs.nss.tools
     pkgs.gh
+    pkgs.typescript-language-server
     (pkgs.callPackage ./tools/convert-to-webp {})
   ];
 


### PR DESCRIPTION
## What

Adds `pkgs.typescript-language-server` to the devenv packages list.

## Why

LSP-based tools (Claude Code's LSP tool, neovim, helix) need an LSP front end for TypeScript. The `typescript` npm dep ships only `tsc` and `tsserver`; `tsserver` speaks its own private protocol, not LSP. This adapter accepts LSP and forwards to the workspace's own `tsserver`, so the TypeScript version that does the analysis stays pinned by `package.json`. VS Code users are unaffected (VS Code talks to tsserver directly).

## Verification

- `nix eval` against the locked nixpkgs input (`8d029aa6`) resolves the attribute (v5.1.3).
- `nix run <pinned>#typescript-language-server -- --version` fetches and runs: `5.1.3`.

After merge: `direnv reload` (or re-enter the repo dir) picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)