### PR TITLE
chore(deps): update @agicash/breez-sdk-spark to 0.23.0-1 (live)

### DIFF
--- a/apps/web-wallet/app/features/receive/lightning-address-service.ts
+++ b/apps/web-wallet/app/features/receive/lightning-address-service.ts
@@ -234,7 +234,7 @@ export class LightningAddressService {
       const lightningQuote = await sparkReceiveQuoteService.getLightningQuote({
         wallet: account.wallet,
         amount: amountToReceive,
-        receiverIdentityPubkey: user.sparkIdentityPublicKey,
+        receiverIdentityPublicKey: user.sparkIdentityPublicKey,
         descriptionHash,
       });
 

--- a/apps/web-wallet/app/features/receive/spark-receive-quote-core.ts
+++ b/apps/web-wallet/app/features/receive/spark-receive-quote-core.ts
@@ -48,7 +48,7 @@ export type GetLightningQuoteParams = {
    * If provided, the incoming payment can only be claimed by the Spark wallet that controls the specified public key.
    * If not provided, the invoice will be created for the user that owns the Spark wallet.
    */
-  receiverIdentityPubkey?: string;
+  receiverIdentityPublicKey?: string;
   /**
    * The description of the receive request (BOLT11 `d` tag).
    */
@@ -231,7 +231,7 @@ export type RepositoryCreateQuoteParams = {
 export async function getLightningQuote({
   wallet,
   amount,
-  receiverIdentityPubkey,
+  receiverIdentityPublicKey,
   description,
   descriptionHash,
 }: GetLightningQuoteParams): Promise<SparkReceiveLightningQuote> {
@@ -241,7 +241,7 @@ export async function getLightningQuote({
         type: 'bolt11Invoice',
         description: description ?? '',
         amountSats: amount.toNumber('sat'),
-        receiverIdentityPubkey,
+        receiverIdentityPublicKey,
         descriptionHash,
       },
     }),
@@ -277,7 +277,7 @@ export async function getLightningQuote({
       memo: description,
     },
     status,
-    receiverIdentityPublicKey: receiverIdentityPubkey,
+    receiverIdentityPublicKey,
   };
 }
 

--- a/apps/web-wallet/app/features/send/spark-send-quote-service.ts
+++ b/apps/web-wallet/app/features/send/spark-send-quote-service.ts
@@ -152,7 +152,7 @@ export class SparkSendQuoteService {
       'BreezSdk.prepareSendPayment',
       () =>
         account.wallet.prepareSendPayment({
-          paymentRequest,
+          paymentRequest: { type: 'input', input: paymentRequest },
           amount: BigInt(amountRequestedInBtc.toNumber('sat')),
         }),
     );
@@ -264,7 +264,7 @@ export class SparkSendQuoteService {
     }
 
     const prepareResponse = await account.wallet.prepareSendPayment({
-      paymentRequest: sendQuote.paymentRequest,
+      paymentRequest: { type: 'input', input: sendQuote.paymentRequest },
       amount: BigInt(sendQuote.amount.toNumber('sat')),
     });
 

--- a/apps/web-wallet/app/features/shared/spark.ts
+++ b/apps/web-wallet/app/features/shared/spark.ts
@@ -110,7 +110,7 @@ export const sparkWalletQueryOptions = ({
               apiKey,
               lnurlDomain: undefined, // Disables Breez's built-in lightning address recovery — we use our own ln address system
               privateEnabledDefault: true,
-              optimizationConfig: {
+              leafOptimizationConfig: {
                 autoEnabled: true,
                 multiplicity: 2,
               },

--- a/apps/web-wallet/app/lib/spark/utils.ts
+++ b/apps/web-wallet/app/lib/spark/utils.ts
@@ -1,4 +1,7 @@
-import { type BreezSdk, defaultExternalSigner } from '@agicash/breez-sdk-spark';
+import {
+  type BreezSdk,
+  defaultExternalSigners,
+} from '@agicash/breez-sdk-spark';
 import { bytesToHex } from '@noble/hashes/utils';
 
 /**
@@ -7,12 +10,12 @@ import { bytesToHex } from '@noble/hashes/utils';
  * @param network - The Breez SDK network ('mainnet' or 'regtest').
  * @returns Hex-encoded compressed public key.
  */
-export function getSparkIdentityPublicKeyFromMnemonic(
+export async function getSparkIdentityPublicKeyFromMnemonic(
   mnemonic: string,
   network: 'mainnet' | 'regtest',
-): string {
-  const signer = defaultExternalSigner(mnemonic, null, network);
-  const publicKey = signer.identityPublicKey();
+): Promise<string> {
+  const signers = defaultExternalSigners(mnemonic, null, network);
+  const publicKey = await signers.sparkSigner.getIdentityPublicKey();
   return bytesToHex(new Uint8Array(publicKey.bytes));
 }
 

--- a/apps/web-wallet/package.json
+++ b/apps/web-wallet/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@agicash/bc-ur": "0.1.0",
-    "@agicash/breez-sdk-spark": "0.13.5-1",
+    "@agicash/breez-sdk-spark": "0.23.0-1",
     "@agicash/opensecret": "catalog:",
     "@agicash/qr-scanner": "0.1.2",
     "@cashu/cashu-ts": "3.6.1",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
       "name": "web-wallet",
       "dependencies": {
         "@agicash/bc-ur": "0.1.0",
-        "@agicash/breez-sdk-spark": "0.13.5-1",
+        "@agicash/breez-sdk-spark": "0.23.0-1",
         "@agicash/opensecret": "catalog:",
         "@agicash/qr-scanner": "0.1.2",
         "@cashu/cashu-ts": "3.6.1",
@@ -129,7 +129,7 @@
   "packages": {
     "@agicash/bc-ur": ["@agicash/bc-ur@0.1.0", "", { "dependencies": { "@apocentre/alias-sampling": "^0.5.3", "@noble/hashes": "^1.3.3", "big.js": "^6.2.2", "buffer": "^6.0.3", "cbor-sync": "^1.0.4", "cborg": "^4.0.9", "jsbi": "3.1.5" } }, "sha512-B2Hh7dSqdeVZuMCwdNR0MXUr4fUU5n+gTWd0b0m9HpV6/mAXRMnAfuJbeax/krvHf8A3qMxFLAkTBKcSxUSPuw=="],
 
-    "@agicash/breez-sdk-spark": ["@agicash/breez-sdk-spark@0.13.5-1", "", { "optionalDependencies": { "better-sqlite3": "^12.2.0", "pg": "^8.18.0" } }, "sha512-Sa8Re7nnT3U2sxxJ77FB1aYcsGSi1yJpBB9mOtE4/F5/WX9+De4eXr6zH/LgMphwrq/Gany3OEmJrvoAaIMqLA=="],
+    "@agicash/breez-sdk-spark": ["@agicash/breez-sdk-spark@0.23.0-1", "", { "optionalDependencies": { "better-sqlite3": "^12.2.0", "pg": "^8.18.0" } }, "sha512-vCX0daoeVaHmDafLhZKWKK07tlRx+SwWyDdGy/7sSZ8fGuX7IH9W12htYRW3J+DM3UCfDELyPm8sOWr+pXNSZQ=="],
 
     "@agicash/opensecret": ["@agicash/opensecret@0.1.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-5cbr7hgKlrY3aLm2RPrk9+xfserhEgG60V+zxtABcD0ZG7Gw6AgeMUuijWyp8mAqZ7G+bZr4Us0ZvGq63ISzog=="],
 


### PR DESCRIPTION
## Summary

Applies #1181 to the `live` branch. Live predates the wallet-sdk extraction, so a cherry-pick did not apply; the same changes are re-applied to the old file layout (`app/lib/spark/utils.ts`, `app/features/shared/spark.ts`, `app/features/send|receive/...`).

- Bumps `@agicash/breez-sdk-spark` from `0.13.5-1` to `0.23.0-1` in `apps/web-wallet` (no catalog move here: on live only one package uses the dep).
- `defaultExternalSigner` → `defaultExternalSigners`; `getSparkIdentityPublicKeyFromMnemonic` is now async. Its only caller on live is the async `queryFn` in `sparkIdentityPublicKeyQueryOptions`, so the change does not ripple.
- `Config.optimizationConfig` → `Config.leafOptimizationConfig`.
- `prepareSendPayment` takes a tagged-union `paymentRequest`: `{ type: 'input', input }` (2 call sites).
- `getLightningQuote` param renamed to `receiverIdentityPublicKey` to match the SDK field (same as the master rename commit).

## Verification

- `bun run fix:all`: clean
- `bun run typecheck`: 3/3 workspaces green
- `bun run test`: 133 pass / 0 fail
- Plain `bun install` passes from the lockfile, so the 3-day `minimumReleaseAge` gate does not block CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)